### PR TITLE
Change importer from geonode.importer to geonode.rest

### DIFF
--- a/dev/settings.py
+++ b/dev/settings.py
@@ -100,7 +100,7 @@ MAP_BASELAYERS = [
 ]
 
 UPLOADER = {
-    'BACKEND': 'geonode.importer',
+    'BACKEND': 'geonode.rest',
     'OPTIONS': {
         'TIME_ENABLED': True,
         'GEOGIG_ENABLED': True,


### PR DESCRIPTION
Enabling the REST uploader in dev/settings.py to prevent users from uploading unsupported file types. 

<img width="811" alt="screen shot 2016-05-27 at 10 15 06 am" src="https://cloud.githubusercontent.com/assets/5116937/15612432/5f0450f6-23f4-11e6-8ad4-0d33da01d20b.png">
