### PR TITLE
Upgrade to master GeoNode

### DIFF
--- a/cf/init_db.sh
+++ b/cf/init_db.sh
@@ -7,7 +7,7 @@ fi
 PASS = $GEONODE_ADMIN_PASSWORD
 
 echo "-----> Create database tables"
-python manage.py syncdb --noinput
+python manage.py migrate --noinput
 
 echo "-----> Create default admin user"
 echo "from geonode.people.models import Profile; Profile.objects.create_superuser('admin', 'admin@boundlessgeo.com', '$PASS')" | python manage.py shell

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -67,7 +67,8 @@ exchange_setup()
     /usr/local/bin/virtualenv /vagrant/.venv
     source /vagrant/.venv/bin/activate
     pip install -r /vagrant/requirements.txt
-    python /vagrant/manage.py syncdb --noinput
+    python /vagrant/manage.py makemigrations
+    python /vagrant/manage.py migrate --noinput
     python /vagrant/manage.py collectstatic --noinput
     #echo "from geonode.people.models import Profile; Profile.objects.create_superuser('admin', 'admin@exchange.com', 'exchange', first_name='Administrator', last_name='Exchange')" | python /vagrant/manage.py shell
     #echo "from geonode.people.models import Profile; Profile.objects.create_user('test', 'test@exchange.com', 'exchange', first_name='Test', last_name='User')" | python /vagrant/manage.py shell
@@ -78,8 +79,8 @@ exchange_setup()
     if ! grep -q 'django-collectstatic' /home/vagrant/.bashrc; then
         printf "\nalias django-collectstatic='/vagrant/.venv/bin/python /vagrant/manage.py collectstatic'" >> /home/vagrant/.bashrc
     fi
-    if ! grep -q 'django-syncdb' /home/vagrant/.bashrc; then
-        printf "\nalias django-syncdb='/vagrant/.venv/bin/python /vagrant/manage.py syncdb'" >> /home/vagrant/.bashrc
+    if ! grep -q 'django-migrate' /home/vagrant/.bashrc; then
+        printf "\nalias django-migrate='/vagrant/.venv/bin/python /vagrant/manage.py migrate'" >> /home/vagrant/.bashrc
     fi
     chmod -R 755 /vagrant/.venv && chown -R vagrant.vagrant /vagrant/.venv
 }

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -67,12 +67,6 @@ exchange_setup()
     /usr/local/bin/virtualenv /vagrant/.venv
     source /vagrant/.venv/bin/activate
     pip install -r /vagrant/requirements.txt
-    pip install git+https://github.com/GeoNode/geonode-announcements --upgrade
-    pip install git+https://github.com/GeoNode/geonode-avatar --upgrade
-    pip install git+https://github.com/GeoNode/geonode-dialogos --upgrade
-    pip install git+https://github.com/GeoNode/geonode-ratings --upgrade
-    pip install git+https://github.com/GeoNode/geonode-user-accounts --upgrade
-    pip install git+https://github.com/GeoNode/geonode-user-messages --upgrade
     python /vagrant/manage.py makemigrations
     python /vagrant/manage.py migrate account --noinput
     python /vagrant/manage.py migrate --noinput

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -67,6 +67,12 @@ exchange_setup()
     /usr/local/bin/virtualenv /vagrant/.venv
     source /vagrant/.venv/bin/activate
     pip install -r /vagrant/requirements.txt
+    pip install git+https://github.com/GeoNode/geonode-announcements --upgrade
+    pip install git+https://github.com/GeoNode/geonode-avatar --upgrade
+    pip install git+https://github.com/GeoNode/geonode-dialogos --upgrade
+    pip install git+https://github.com/GeoNode/geonode-ratings --upgrade
+    pip install git+https://github.com/GeoNode/geonode-user-accounts --upgrade
+    pip install git+https://github.com/GeoNode/geonode-user-messages --upgrade
     python /vagrant/manage.py makemigrations
     python /vagrant/manage.py migrate --noinput
     python /vagrant/manage.py collectstatic --noinput

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -74,6 +74,7 @@ exchange_setup()
     pip install git+https://github.com/GeoNode/geonode-user-accounts --upgrade
     pip install git+https://github.com/GeoNode/geonode-user-messages --upgrade
     python /vagrant/manage.py makemigrations
+    python /vagrant/manage.py migrate account --noinput
     python /vagrant/manage.py migrate --noinput
     python /vagrant/manage.py collectstatic --noinput
     #echo "from geonode.people.models import Profile; Profile.objects.create_superuser('admin', 'admin@exchange.com', 'exchange', first_name='Administrator', last_name='Exchange')" | python /vagrant/manage.py shell

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 --index-url https://pypi.python.org/simple/
 
--e git://github.com/boundlessgeo/geonode.git@whitenoise_patch#egg=geonode
+-e git://github.com/GeoNode/geonode.git@master#egg=geonode
 -e git://github.com/boundlessgeo/django-geoexplorer.git@whitenoise_patch#egg=django-geoexplorer
 -e git://github.com/ROGUE-JCTD/django-maploom.git@bc4d3dd49edd9932f8ec2d2061ad37d78a603d07#egg=django-maploom
 whitenoise==2.0.6
-django-tastypie==0.11.0
 django-cors-headers==1.1.0
 django-classification-banner==0.1.5
 django-solo==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,11 @@
 --index-url https://pypi.python.org/simple/
 
+-e git://github.com/GeoNode/geonode-announcements@master#egg=geonode-announcements
+-e git://github.com/GeoNode/geonode-avatar@master#egg=geonote-avatar
+-e git://github.com/GeoNode/geonode-dialogos.git@master#egg=geonode-dialogos
+-e git://github.com/GeoNode/geonode-ratings.git@master#egg=geonode-ratings
+-e git://github.com/GeoNode/geonode-user-accounts.git@master#egg=geonode-user-accounts
+-e git://github.com/GeoNode/geonode-user-messages.git@master#egg=geonode-user-messages
 -e git://github.com/GeoNode/geonode.git@master#egg=geonode
 -e git://github.com/boundlessgeo/django-geoexplorer.git@whitenoise_patch#egg=django-geoexplorer
 -e git://github.com/ROGUE-JCTD/django-maploom.git@bc4d3dd49edd9932f8ec2d2061ad37d78a603d07#egg=django-maploom


### PR DESCRIPTION
Updates Exchange to use the latest GeoNode master, which means a bump to Django 1.8 (among other things). `django-tastypie` has also been unpinned from our own deps to let us pull the appropriate version (matched to Django version) via GeoNode.

Also updates Exchange's use of `syncdb` to use `migrate` instead, as `syncdb` has been deprecated and is going away completely in Django 1.9.

Fair warning, I'm unfamiliar with everything else that changed with the move from our previous, much-older pinned GeoNode version to GeoNode master - so I'm not sure if there's a more complete QA process to be run here other than "works on my box".

**storytime:**

There is an issue with interdependent migrations. (related: [this](https://lists.osgeo.org/pipermail/geonode-devel/2016-February/000780.html) ML post). After the initial `makemigrations`, running `migrate` will fail with `ProgrammingError: relation "people_profile" does not exist`. Attempting to migrate `people` throws a different "relation does not exist" error (this time, for `sites`). I could list all the permutations of trying to migrate a particular app containing a missing relation first, but TL;DR: they all depend on something else, that depends on something else... The smallest & best fix I could find for this is to add the initial migration for `sites` as a dependency on `accounts`: i.e., add `('sites', '0001_initial'),` [here](https://github.com/GeoNode/geonode-user-accounts/blob/master/account/migrations/0001_initial.py#L34)).

~~I haven't PR'd that fix yet, pending further discussion. For now attempting `vagrant provision` with the bootstrap script in this PR will error on a "relation does not exist". Until the dependency on `sites` is added in to the initial migration in `geonode-user-accounts`, you can modify the migration file locally and manually apply migrations.~~ **Update**: this fix is now in geonode core, so `vagrant provision` should work fine with this PR's bootstrap.
