### PR TITLE
add change doc with new migration steps

### DIFF
--- a/dev/CHANGELOG.md
+++ b/dev/CHANGELOG.md
@@ -1,0 +1,18 @@
+### 2016-05-22
+
+* *Upgraded to use GeoNode 2.4, Django 1.8.7*
+
+    Exchange now uses native Django migrations to initialize its database.
+
+To initialize against a new/empty database instance, do the following
+one-time migration steps:
+
+```bash
+$ python manage.py makemigrations
+$ python manage.py migrate account --noinput
+$ python manage.py migrate --noinput
+```
+
+Once migrations are complete, continue with usage as normal.
+
+


### PR DESCRIPTION
Ref: https://issues.boundlessgeo.com:8443/browse/NODE-158

Added a changelog to track significant changes; documented migration steps needed to go from Django 1.6 --> Django 1.8.x