### PR TITLE
NODE-163: integrate osgeo importer

### DIFF
--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -79,6 +79,9 @@ exchange_setup()
     if ! grep -q 'django-runserver' /home/vagrant/.bashrc; then
         printf "\nalias django-runserver='/vagrant/.venv/bin/python /vagrant/manage.py runserver 0.0.0.0:8000'" >> /home/vagrant/.bashrc
     fi
+    if ! grep -q 'django-celeryworker' /home/vagrant/.bashrc; then
+        printf "\nalias django-celeryworker='/vagrant/.venv/bin/python /vagrant/manage.py celery worker -E --loglevel=DEBUG'" >> /home/vagrant/.bashrc
+    fi
     if ! grep -q 'django-collectstatic' /home/vagrant/.bashrc; then
         printf "\nalias django-collectstatic='/vagrant/.venv/bin/python /vagrant/manage.py collectstatic'" >> /home/vagrant/.bashrc
     fi

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -138,10 +138,24 @@ database_setup()
     else
         psql -U postgres -c "ALTER USER exchange WITH PASSWORD 'boundless';"
     fi
+
+    OSUSER=$(psql -U postgres -c '\du' | cut -d \| -f 1 | grep -w osgeo | wc -l)
+    if [ $OSUSER == 0 ]; then
+        psql -U postgres -c "CREATE USER osgeo with password 'osgeo';"
+    else
+        psql -U postgres -c "ALTER USER osgeo with password 'osgeo';"
+    fi
+
     EXCHANGE_DB=$(psql -U postgres -lqt | cut -d \| -f 1 | grep -w exchange | wc -l)
     if [ $EXCHANGE_DB == 1 ]; then
         psql -U postgres -c "DROP DATABASE exchange;"
     fi
+
+    OSGEO_DB=$(psql -U postgres -lqt | cut -d \| -f 1 | grep -w osgeo_importer_test | wc -l)
+    if [ $OSGEO_DB == 1 ]; then
+        psql -U postgres -c "DROP DATABASE osgeo_importer_test;"
+    fi
+
     psql -U postgres -c "CREATE DATABASE exchange OWNER exchange;"
     EXCHANGE_DATA_DB=$(psql -U postgres -lqt | cut -d \| -f 1 | grep -w exchange_data | wc -l)
     if [ $EXCHANGE_DATA_DB == 1 ]; then
@@ -151,6 +165,11 @@ database_setup()
     psql -U postgres -d exchange_data -c 'CREATE EXTENSION postgis;'
     psql -U postgres -d exchange_data -c 'GRANT ALL ON geometry_columns TO PUBLIC;'
     psql -U postgres -d exchange_data -c 'GRANT ALL ON spatial_ref_sys TO PUBLIC;'
+
+    psql -U postgres -c "CREATE DATABASE osgeo_importer_test OWNER osgeo;"
+    psql -U postgres -d osgeo_importer_test -c "CREATE EXTENSION postgis"
+    psql -U postgres -d osgeo_importer_test -c 'GRANT ALL ON geometry_columns TO PUBLIC;'
+    psql -U postgres -d osgeo_importer_test -c 'GRANT ALL ON spatial_ref_sys TO PUBLIC;'
 }
 
 gs-dev_init()

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -139,21 +139,9 @@ database_setup()
         psql -U postgres -c "ALTER USER exchange WITH PASSWORD 'boundless';"
     fi
 
-    OSUSER=$(psql -U postgres -c '\du' | cut -d \| -f 1 | grep -w osgeo | wc -l)
-    if [ $OSUSER == 0 ]; then
-        psql -U postgres -c "CREATE USER osgeo with password 'osgeo';"
-    else
-        psql -U postgres -c "ALTER USER osgeo with password 'osgeo';"
-    fi
-
     EXCHANGE_DB=$(psql -U postgres -lqt | cut -d \| -f 1 | grep -w exchange | wc -l)
     if [ $EXCHANGE_DB == 1 ]; then
         psql -U postgres -c "DROP DATABASE exchange;"
-    fi
-
-    OSGEO_DB=$(psql -U postgres -lqt | cut -d \| -f 1 | grep -w osgeo_importer_test | wc -l)
-    if [ $OSGEO_DB == 1 ]; then
-        psql -U postgres -c "DROP DATABASE osgeo_importer_test;"
     fi
 
     psql -U postgres -c "CREATE DATABASE exchange OWNER exchange;"
@@ -165,11 +153,6 @@ database_setup()
     psql -U postgres -d exchange_data -c 'CREATE EXTENSION postgis;'
     psql -U postgres -d exchange_data -c 'GRANT ALL ON geometry_columns TO PUBLIC;'
     psql -U postgres -d exchange_data -c 'GRANT ALL ON spatial_ref_sys TO PUBLIC;'
-
-    psql -U postgres -c "CREATE DATABASE osgeo_importer_test OWNER osgeo;"
-    psql -U postgres -d osgeo_importer_test -c "CREATE EXTENSION postgis"
-    psql -U postgres -d osgeo_importer_test -c 'GRANT ALL ON geometry_columns TO PUBLIC;'
-    psql -U postgres -d osgeo_importer_test -c 'GRANT ALL ON spatial_ref_sys TO PUBLIC;'
 }
 
 gs-dev_init()

--- a/dev/settings.sh
+++ b/dev/settings.sh
@@ -9,7 +9,6 @@ export LOCKDOWN_GEONODE=True
 export BROKER_URL='amqp://guest:guest@localhost:5672/'
 export DATABASE_URL='postgres://exchange:boundless@localhost:5432/exchange'
 export POSTGIS_URL='postgis://exchange:boundless@localhost:5432/exchange_data'
-export OSGEO_DATASTORE_URL='postgis://exchange:boundless@localhost:5432/osgeo_importer_test'
 export GEOSERVER_URL='http://192.168.99.110:8888/proxy/http://192.168.99.110:8080/geoserver/'
 export GEOSERVER_DATA_DIR='/vagrant/dev/.geoserver/data'
 export GEOSERVER_LOG='/vagrant/dev/.geoserver/data/logs/geoserver.log'

--- a/dev/settings.sh
+++ b/dev/settings.sh
@@ -9,6 +9,7 @@ export LOCKDOWN_GEONODE=True
 export BROKER_URL='amqp://guest:guest@localhost:5672/'
 export DATABASE_URL='postgres://exchange:boundless@localhost:5432/exchange'
 export POSTGIS_URL='postgis://exchange:boundless@localhost:5432/exchange_data'
+export OSGEO_DATASTORE_URL='postgis://exchange:boundless@localhost:5432/osgeo_importer_test'
 export GEOSERVER_URL='http://192.168.99.110:8888/proxy/http://192.168.99.110:8080/geoserver/'
 export GEOSERVER_DATA_DIR='/vagrant/dev/.geoserver/data'
 export GEOSERVER_LOG='/vagrant/dev/.geoserver/data/logs/geoserver.log'

--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -21,17 +21,29 @@
 from django.conf import settings
 from exchange.version import get_version
 
+
 def version(request):
     """ Returns the exchange version """
 
     return dict(VERSION=get_version())
+
 
 def registry(request):
     """ Registry variable to pass to templates"""
 
     return {'REGISTRY': settings.REGISTRY}
 
+
 def map_crs(request):
     """ Map CRS variable to pass to templates"""
 
     return {'MAP_CRS': settings.DEFAULT_MAP_CRS}
+
+
+def template_globals(request):
+    """Global values to pass to templates"""
+
+    defaults = dict(
+        USE_OSGEO_IMPORTER=('osgeo_importer' in settings.INSTALLED_APPS)
+    )
+    return defaults

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -77,6 +77,7 @@ TEMPLATE_CONTEXT_PROCESSORS += (
     'exchange.core.context_processors.version',
     'exchange.core.context_processors.registry',
     'exchange.core.context_processors.map_crs',
+    'exchange.core.context_processors.template_globals',
 )
 
 # middlware
@@ -95,7 +96,9 @@ INSTALLED_APPS = (
     'solo',
     'colorfield',
     'haystack',
-    'corsheaders'
+    'corsheaders',
+    'osgeo_importer',
+    'kombu.transport.django'
 ) + INSTALLED_APPS
 
 # cors settings
@@ -148,10 +151,15 @@ DATABASE_URL = os.getenv('DATABASE_URL', SQLITEDB)
 DATABASES['default'] = dj_database_url.parse(DATABASE_URL,
                                              conn_max_age=600)
 POSTGIS_URL = os.environ.get('POSTGIS_URL', None)
+OSGEO_DATASTORE_URL = os.environ.get('OSGEO_DATASTORE_URL', None)
 if POSTGIS_URL is not None:
     DATABASES['exchange_imports'] = dj_database_url.parse(POSTGIS_URL,
                                                           conn_max_age=600)
     OGC_SERVER['default']['DATASTORE'] = 'exchange_imports'
+
+if OSGEO_DATASTORE_URL is not None:
+    DATABASES['datastore'] = dj_database_url.parse(OSGEO_DATASTORE_URL,
+                                                 conn_max_age=600)
 
 UPLOADER = {
     'BACKEND': 'geonode.importer',
@@ -281,6 +289,11 @@ if REGISTRY is not None:
     }
     TAGGIT_CASE_INSENSITIVE = True
 
+# osgeo_importer-specific settings
+if 'osgeo_importer' in INSTALLED_APPS:
+    OSGEO_IMPORTER_GEONODE_ENABLED = True
+    CELERY_IMPORTS += ('osgeo_importer.tasks',)
+    CELERY_IGNORE_RESULT = False
 
 try:
     from local_settings import *  # noqa

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -289,6 +289,36 @@ if REGISTRY is not None:
     }
     TAGGIT_CASE_INSENSITIVE = True
 
+# Debug logging config; override to reduce noise in prod
+LOGGING = {
+    'version': 1,
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'propagate': True,
+            'level': 'INFO',  # django's root logger is too noisy at DEBUG
+        },
+        'osgeo_importer': {
+            'handlers': ['console'],
+            'propagate': True,
+            'level': 'DEBUG',
+        },
+    },
+}
+DEBUG_PROPAGATE_EXCEPTIONS = True
+
+# uncomment the following two lines to let tastypie exceptions log to console
+# instead of response body (this will be fixed in upcoming tastypie release;
+# reference: https://github.com/django-tastypie/django-tastypie/pull/1376)
+# DEBUG = False
+# ALLOWED_HOSTS = ['*']
+
 # osgeo_importer-specific settings
 if 'osgeo_importer' in INSTALLED_APPS:
     OSGEO_IMPORTER_GEONODE_ENABLED = True

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -151,15 +151,14 @@ DATABASE_URL = os.getenv('DATABASE_URL', SQLITEDB)
 DATABASES['default'] = dj_database_url.parse(DATABASE_URL,
                                              conn_max_age=600)
 POSTGIS_URL = os.environ.get('POSTGIS_URL', None)
-OSGEO_DATASTORE_URL = os.environ.get('OSGEO_DATASTORE_URL', None)
 if POSTGIS_URL is not None:
     DATABASES['exchange_imports'] = dj_database_url.parse(POSTGIS_URL,
                                                           conn_max_age=600)
     OGC_SERVER['default']['DATASTORE'] = 'exchange_imports'
 
-if OSGEO_DATASTORE_URL is not None:
-    DATABASES['datastore'] = dj_database_url.parse(OSGEO_DATASTORE_URL,
-                                                 conn_max_age=600)
+    if 'osgeo_importer' in INSTALLED_APPS:
+        # specify which postgis db osgeo_importer name should reference
+        OSGEO_DATASTORE = 'exchange_imports'
 
 UPLOADER = {
     'BACKEND': 'geonode.importer',

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -156,9 +156,13 @@ if POSTGIS_URL is not None:
                                                           conn_max_age=600)
     OGC_SERVER['default']['DATASTORE'] = 'exchange_imports'
 
-    if 'osgeo_importer' in INSTALLED_APPS:
-        # specify which postgis db osgeo_importer name should reference
-        OSGEO_DATASTORE = 'exchange_imports'
+OSGEO_DATASTORE_URL = os.environ.get('OSGEO_DATASTORE_URL', None)
+if OSGEO_DATASTORE_URL is not None:
+    DATABASES['osgeo_imports'] = dj_database_url.parse(OSGEO_DATASTORE_URL,
+                                                       conn_max_age=600)
+    OSGEO_DATASTORE = 'osgeo_imports'
+else:
+    OSGEO_DATASTORE = 'exchange_imports'
 
 UPLOADER = {
     'BACKEND': 'geonode.importer',

--- a/exchange/templates/base.html
+++ b/exchange/templates/base.html
@@ -206,6 +206,14 @@
           </div>
           <div class="modal-body">
             <ul class="list-unstyled">
+              {% if REGISTRY %}
+              <li><a href="/registry/search/csw?service=CSW&version=2.0.2&request=GetCapabilities"><i class="fa fa-globe"></i> {% trans "Registry CSW Endpoint" %}</a></li>
+              {% endif %}
+              <li><a href="/catalogue/search/csw?service=CSW&version=2.0.2&request=GetCapabilities"><i class="fa fa-globe"></i> {% trans "Exchange CSW Endpoint" %}</a></li>
+              {% if USE_OSGEO_IMPORTER %}
+                  <li><a href="{% url "uploads-list" %}"><i class="fa fa-th-list"></i> {% trans "Staged Layers" %}</a></li>
+              {% endif %}
+              <li class="modal-divider"></li>
               <li><a href="{{ user.get_absolute_url }}"><i class="fa fa-user"></i> {% trans "Profile" %}</a></li>
               <li><a href="{% url "recent-activity" %}"><i class="fa fa-fire"></i> {% trans "Recent Activity" %}</a></li>
               <li><a href="{% url "messages_inbox" %}"><i class="fa fa-inbox"></i> {% trans "Inbox" %}</a></li>

--- a/exchange/templates/base.html
+++ b/exchange/templates/base.html
@@ -206,10 +206,6 @@
           </div>
           <div class="modal-body">
             <ul class="list-unstyled">
-              {% if REGISTRY %}
-              <li><a href="/registry/search/csw?service=CSW&version=2.0.2&request=GetCapabilities"><i class="fa fa-globe"></i> {% trans "Registry CSW Endpoint" %}</a></li>
-              {% endif %}
-              <li><a href="/catalogue/search/csw?service=CSW&version=2.0.2&request=GetCapabilities"><i class="fa fa-globe"></i> {% trans "Exchange CSW Endpoint" %}</a></li>
               {% if USE_OSGEO_IMPORTER %}
                   <li><a href="{% url "uploads-list" %}"><i class="fa fa-th-list"></i> {% trans "Staged Layers" %}</a></li>
               {% endif %}

--- a/exchange/urls.py
+++ b/exchange/urls.py
@@ -19,7 +19,6 @@
 #########################################################################
 
 from django.conf.urls import patterns, url
-from django.views.generic import TemplateView
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from maploom.geonode.urls import urlpatterns as maploom_urls

--- a/exchange/urls.py
+++ b/exchange/urls.py
@@ -22,7 +22,8 @@ from django.conf.urls import patterns, url
 from django.views.generic import TemplateView
 from maploom.geonode.urls import urlpatterns as maploom_urls
 from hypermap.urls import urlpatterns as hypermap_urls
-from geonode.urls import *
+from osgeo_importer.urls import urlpatterns as osgeo_importer_urls
+from geonode.urls import urlpatterns as geonode_urls
 from . import views
 
 js_info_dict = {
@@ -38,7 +39,9 @@ urlpatterns = patterns(
         name='map_metadata_detail'),
     url(r'^wfsproxy/', views.geoserver_reverse_proxy,
             name='geoserver_reverse_proxy')
- ) + urlpatterns
+ )
 
+urlpatterns += geonode_urls
 urlpatterns += maploom_urls
 urlpatterns += hypermap_urls
+urlpatterns += osgeo_importer_urls

--- a/exchange/urls.py
+++ b/exchange/urls.py
@@ -20,9 +20,12 @@
 
 from django.conf.urls import patterns, url
 from django.views.generic import TemplateView
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from maploom.geonode.urls import urlpatterns as maploom_urls
 from hypermap.urls import urlpatterns as hypermap_urls
 from osgeo_importer.urls import urlpatterns as osgeo_importer_urls
+from osgeo_importer.views import FileAddView
 from geonode.urls import urlpatterns as geonode_urls
 from . import views
 
@@ -41,7 +44,15 @@ urlpatterns = patterns(
             name='geoserver_reverse_proxy')
  )
 
+
+if 'osgeo_importer' in settings.INSTALLED_APPS:
+    # if using osgeo_importer, intercept the usual layers/upload view in order
+    # to use alternate UI (from django_osgeo_importer)
+    urlpatterns += [url(r'^layers/upload$',
+                        login_required(FileAddView.as_view()),
+                        name='layer_upload')]
+    urlpatterns += osgeo_importer_urls
+
 urlpatterns += geonode_urls
 urlpatterns += maploom_urls
 urlpatterns += hypermap_urls
-urlpatterns += osgeo_importer_urls

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,11 @@ git+git://github.com/GeoNode/geonode-ratings.git@1190af087157e91bb873e624f161b1e
 git+git://github.com/GeoNode/geonode-user-accounts.git@475bf0875658dc4dc66120e3322643ad7cc54973#egg=geonode-user-accounts
 git+git://github.com/GeoNode/geonode-user-messages.git@c0167cb2d956d84119ec5468ab3ceb398576f871#egg=geonode-user-messages
 git+git://github.com/ROGUE-JCTD/django-maploom.git@bc4d3dd49edd9932f8ec2d2061ad37d78a603d07#egg=django-maploom
+git+git://github.com/terranodo/django-mapproxy.git@registry#egg=django-mapproxy
+git+git://github.com/cga-harvard/HHypermap.git@registry#egg=hypermap
+git+git://github.com/terranodo/mapproxy.git@master#egg=mapproxy
+git+git://github.com/geopython/pycsw.git@master#egg=pycsw
+git+git://github.com/ProminentEdge/django-osgeo-importer@master#egg=django-osgeo-importer
 dj-database-url==0.4.1
 django-storages==1.1.8
 boto==2.38.0
@@ -25,8 +30,5 @@ supervisor==3.2.3
 gunicorn==19.4.5
 corsa==0.1.2
 python-resize-image==1.1.10
-git+git://github.com/terranodo/django-mapproxy.git@registry#egg=django-mapproxy
-git+git://github.com/cga-harvard/HHypermap.git@registry#egg=hypermap
-git+git://github.com/terranodo/mapproxy.git@master#egg=mapproxy
-git+git://github.com/geopython/pycsw.git@master#egg=pycsw
+numpy==1.11.0
 pdb


### PR DESCRIPTION
Ref: https://issues.boundlessgeo.com:8443/browse/NODE-163 (and related sub-tasks)

~~**CAVEAT: pending [NODE-198](https://issues.boundlessgeo.com:8443/browse/NODE-198), this is vector import only.** 
NODE-198 will fix geoTIFF imports in osgeo-importer~~

*local dev notes:*

* This is dependent on current open PRs on `django-osgeo-importer` upstream; this branch contains all PR commits if needed for immediate local testing: 
https://github.com/boundlessgeo/django-osgeo-importer/tree/exchange-integration

* Using osgeo-importer requires a celery worker to be active (even in dev) - to kick off a worker you can use the new convenience command, `django-celeryworker` (to be run concurrently with `django-runserver`)

*Screenshots:*

![image](https://cloud.githubusercontent.com/assets/1209376/16691479/6f176734-44f2-11e6-8dda-3a6932e27890.png)
*Using django-importer UI to add new data*

![image](https://cloud.githubusercontent.com/assets/1209376/16691464/60f62898-44f2-11e6-98d1-612bcc773dae.png)
*New: list of staged layers*

![image](https://cloud.githubusercontent.com/assets/1209376/16691546/a6a50364-44f2-11e6-8d41-2f8d0477036d.png)
*Using osgeo-importer's UI*

![image](https://cloud.githubusercontent.com/assets/1209376/16691393/33647a74-44f2-11e6-9d46-8389d5fbfd46.png)
*Link to access staged layer list, new in user menu*
