### PR TITLE
Fix category icon alignment

### DIFF
--- a/exchange/static/css/site_base.css
+++ b/exchange/static/css/site_base.css
@@ -124,6 +124,11 @@ nav.filter h4 a.toggle {
   -webkit-transform:rotate(50deg) skewX(24deg) skewY(12deg);
   -ms-transform:rotate(50deg) skewX(24deg) skewY(12deg);
 }
+.fa-hero {
+  top: 25px;
+  vertical-align: inherit;
+
+}
 .stacked {
   margin-top: 28px;
 }

--- a/exchange/static/css/site_base.css
+++ b/exchange/static/css/site_base.css
@@ -124,11 +124,6 @@ nav.filter h4 a.toggle {
   -webkit-transform:rotate(50deg) skewX(24deg) skewY(12deg);
   -ms-transform:rotate(50deg) skewX(24deg) skewY(12deg);
 }
-.fa-stack {
-  top: 25px;
-  vertical-align: inherit;
-
-}
 .stacked {
   margin-top: 28px;
 }

--- a/exchange/templates/site_index.html
+++ b/exchange/templates/site_index.html
@@ -38,7 +38,7 @@
       <div class="col-md-4">
         <a class="info-blurb" href="{% url "layer_browse" %}">
           <p class="text-center">
-            <span class="fa-stack fa-rotate-90 fa-2x" >
+            <span class="fa-stack fa-hero fa-rotate-90 fa-2x" >
               <i class="fa fa-stop fa-layers fa-stack-1x fa-2x" style="left: 0;"></i>
               <i class="fa fa-stop fa-layers fa-stack-1x fa-2x" style="left: -.15em;color:#E6E9ED;"></i>
               <i class="fa fa-stop fa-layers fa-stack-1x fa-2x" style="left: -.3em;"></i>


### PR DESCRIPTION
[NODE-214](https://issues.boundlessgeo.com:8443/browse/NODE-214)

No need to override geonode's styles here just to change alignment on one icon ("Layers" on index). The old override was messing with icon-to-text alignment across the site.