### PR TITLE
link directly to first page of query results to skip redirect

### DIFF
--- a/exchange/templates/base.html
+++ b/exchange/templates/base.html
@@ -54,21 +54,21 @@
           <ul class="nav navbar-nav">
             {% block tabs %}
             <li id="nav_layers">
-              <a href="{% url "layer_browse" %}">{% trans "Layers" %}</a>
+              <a href="{% url "layer_browse" %}?limit=100&offset=0">{% trans "Layers" %}</a>
             </li>
             <li id="nav_maps">
-              <a href="{% url "maps_browse" %}">{% trans "Maps" %}</a>
+              <a href="{% url "maps_browse" %}?limit=100&offset=0">{% trans "Maps" %}</a>
             </li>
             <li id="nav_documents">
-              <a href="{% url "document_browse" %}">{% trans "Documents" %}</a>
+              <a href="{% url "document_browse" %}?limit=100&offset=0">{% trans "Documents" %}</a>
             </li>
            {% block extra_tab %}
            {% endblock %}
             <li id="nav_people">
-              <a href="{% url "profile_browse" %}">{% trans "People" %}</a>
+              <a href="{% url "profile_browse" %}?limit=100&offset=0">{% trans "People" %}</a>
             </li>
             <li id="nav_groups">
-              <a href="{% url "group_list" %}">{% trans "Groups" %}</a>
+              <a href="{% url "group_list" %}?limit=100&offset=0">{% trans "Groups" %}</a>
             </li>
             {% endblock %}
           </ul>

--- a/exchange/templates/site_index.html
+++ b/exchange/templates/site_index.html
@@ -36,7 +36,7 @@
     {% with facet_type='home' %}
      {% facets as facets %}
       <div class="col-md-4">
-        <a class="info-blurb" href="{% url "layer_browse" %}">
+       <a class="info-blurb" href="{% url "layer_browse" %}?limit=100&offset=0">
           <p class="text-center">
             <span class="fa-stack fa-rotate-90 fa-2x" >
               <i class="fa fa-stop fa-layers fa-stack-1x fa-2x" style="left: 0;"></i>
@@ -49,29 +49,29 @@
           <h2 class="text-center stacked">{{ facets.layer|default:"No" }} Layer{{ facets.layer|pluralize }}</h2>
           <p class="text-center blurb">{% trans "Browse or upload geospatial data into an Exchange layer. Download them in the format you need." %}</p>
           <p class="text-center">
-              <a class="btn btn-default" href="{% url "layer_browse" %}" role="button">{% trans "Browse" %} &raquo;</a>
-              <a class="btn btn-default" href="{% url "layer_upload" %}" role="button">{% trans "Upload" %} &raquo;</a>
+              <a class="btn btn-default" href="{% url "layer_browse" %}?limit=100&offset=0" role="button">{% trans "Browse" %} &raquo;</a>
+              <a class="btn btn-default" href="{% url "layer_upload" %}"  role="button">{% trans "Upload" %} &raquo;</a>
           </p>
         </a>
       </div>
       <div class="col-md-4">
-        <a class="info-blurb" href="{% url "document_browse" %}">
+        <a class="info-blurb" href="{% url "document_browse" %}?limit=100&offset=0">
           <p class="text-center"><i class="fa fa-files-o fa-5x"></i></p>
           <h2 class="text-center">{{ facets.document|default:"No" }} Document{{ facets.document|pluralize }}</h2>
           <p class="text-center blurb">{% trans "Browse or upload non geospatial data and associate your data to a layer or map." %}</p>
           <p class="text-center">
-              <a class="btn btn-default" href="{% url "document_browse" %}" role="button">{% trans "Browse" %} &raquo;</a>
+              <a class="btn btn-default" href="{% url "document_browse" %}?limit=100&offset=0" role="button">{% trans "Browse" %} &raquo;</a>
               <a class="btn btn-default" href="{% url "document_upload" %}" role="button">{% trans "Upload" %} &raquo;</a>
           </p>
         </a>
       </div>
       <div class="col-md-4">
-        <a class="info-blurb" href="{% url "maps_browse" %}">
+        <a class="info-blurb" href="{% url "maps_browse" %}?limit=100&offset=0">
           <p class="text-center"><i class="fa fa-map fa-5x"></i></p>
           <h2 class="text-center">{{ facets.map|default:"No" }} Map{{ facets.map|pluralize }}</h2>
           <p class="text-center blurb">{% trans "Browse or create a map and allow others to collaborate on your map with comments or edits." %}</p>
           <p class="text-center">
-              <a class="btn btn-default" href="{% url "maps_browse" %}" role="button">{% trans "Browse" %} &raquo;</a>
+              <a class="btn btn-default" href="{% url "maps_browse" %}?limit=100&offset=0" role="button">{% trans "Browse" %} &raquo;</a>
               <a class="btn btn-default" href="{% url "new_map" %}" role="button">{% trans "Create" %} &raquo;</a>
           </p>
         </a>


### PR DESCRIPTION
resources redirect automatically to the first page of query results;
this "breaks" user expectations of the back button (requiring two clicks
to back out through the redirect & return to previous page).

REF: https://issues.boundlessgeo.com:8443/browse/NODE-215 & https://issues.boundlessgeo.com:8443/browse/NODE-216