### PR TITLE
use setuptools to find subpackages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@
 #########################################################################
 
 import os
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 
 def read(*rnames):
@@ -40,7 +40,7 @@ setup(
     license="BSD",
     keywords="exchange geonode django",
     url='https://github.com/boundlessgeo/exchange',
-    packages=['exchange', ],
+    packages=find_packages('.'),
     include_package_data=True,
     zip_safe=False,
     install_requires=[


### PR DESCRIPTION
Right now if you `pip install ./exchange` (or the like) the resulting install will not include subpackages such as exchange.settings in the copy installed in site-packages, because the relevant distutils function does not search subdirectories. This is at least one barrier to using the package in-place from a pip install, requiring it to be used from a copy of the source tree.