### PR TITLE
Replace single with double quotes in config catalog list

### DIFF
--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -243,8 +243,8 @@ if REGISTRY is not None:
     REGISTRYURL = '%s/registry' % SITE_URL.rstrip('/')
     CATALOGLIST = [
         {
-            'name': 'local registry',
-            'url': '%s/hypermap/' % SITE_URL.rstrip('/')
+            "name": "local registry",
+            "url": "%s/hypermap/" % SITE_URL.rstrip("/")
         },
     ]
     SEARCH_ENABLED = True


### PR DESCRIPTION
The catalog list from the default config gets passed to MapLoom as a string that needs to be parsed using JSON.parse(), which requires that all JSON keys be wrapped in double quotes. 