### PR TITLE
remove redundant call to os.path.join

### DIFF
--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -54,8 +54,8 @@ WSGI_APPLICATION = "exchange.wsgi.application"
 ROOT_URLCONF = 'exchange.urls'
 
 LOCAL_ROOT = os.path.abspath(os.path.dirname(__file__))
-APP_ROOT = os.path.join(os.path.join(LOCAL_ROOT, os.pardir))
-PROJECT_ROOT = os.path.join(os.path.join(APP_ROOT, os.pardir))
+APP_ROOT = os.path.join(LOCAL_ROOT, os.pardir)
+PROJECT_ROOT = os.path.join(APP_ROOT, os.pardir)
 
 # static files storage
 STATICFILES_DIRS.append(os.path.join(APP_ROOT, "static"),)


### PR DESCRIPTION
with only a first argument, os.path.join(x) == x.
[See the source in posixpath.py](https://hg.python.org/cpython/file/2.7/Lib/posixpath.py#l61) if you need to prove this to yourself