### PR TITLE
Uploaded resources should be private and not downloadable by default

### DIFF
--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -308,3 +308,8 @@ try:
     from local_settings import *  # noqa
 except ImportError:
     pass
+
+# Uploaded resources should be private and not downloadable by default
+# Overwrite the default of True found in the base Geonode settings
+DEFAULT_ANONYMOUS_VIEW_PERMISSION = False
+DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION = False


### PR DESCRIPTION
This PR support NODE-41.

<img width="618" alt="screen shot 2016-08-02 at 3 07 16 pm" src="https://cloud.githubusercontent.com/assets/947403/17343306/95a74d2c-58c2-11e6-8695-b8a2ad4a904d.png">
