### PR TITLE
Use https:// in Gravatar URLs generated through django-avatar

### DIFF
--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -313,3 +313,6 @@ except ImportError:
 # Overwrite the default of True found in the base Geonode settings
 DEFAULT_ANONYMOUS_VIEW_PERMISSION = False
 DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION = False
+
+# Use https:// scheme in Gravatar URLs
+AVATAR_GRAVATAR_SSL = True


### PR DESCRIPTION
Per https://issues.boundlessgeo.com:8443/browse/NODE-310.
Seems to work for me, but I'm not sure what all this affects, so this needs testing/inspection from someone more familiar with the issue.