### PR TITLE
tidy import of urls from geonode

### DIFF
--- a/exchange/urls.py
+++ b/exchange/urls.py
@@ -22,7 +22,7 @@ from django.conf.urls import patterns, url
 from django.views.generic import TemplateView
 from maploom.geonode.urls import urlpatterns as maploom_urls
 from hypermap.urls import urlpatterns as hypermap_urls
-from geonode.urls import *
+from geonode.urls import urlpatterns as geonode_urls
 from . import views
 
 js_info_dict = {
@@ -38,7 +38,8 @@ urlpatterns = patterns(
         name='map_metadata_detail'),
     url(r'^wfsproxy/', views.geoserver_reverse_proxy,
             name='geoserver_reverse_proxy')
- ) + urlpatterns
+ )
 
+urlpatterns += geonode_urls
 urlpatterns += maploom_urls
 urlpatterns += hypermap_urls


### PR DESCRIPTION
The way these lines have been is pretty confusing because it drags in geonode.urls.urlpatterns (which makes things confusing when we want to bring in urlpatterns from other places) and then it modifies it in the current scope. You need a very solid understanding of Python to understand how this worked.

I also want to get rid of `import *` wherever possible, it never should have existed in Python, and this is a relatively easy instance to get rid of

This is part of prep for a rebased version of Sara's django-osgeo-importer PR from June