### PR TITLE
remove shell aliases in docker config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,6 @@ RUN /env/bin/pip install -r /mnt/exchange/requirements.txt && \
 # docker/home contains a number of things that will go in $HOME:
 # - local_settings.py: env-specific monkeypatches for django's settings.py
 # - .bash_profile: for activating the virtualenv at login
-# - .bashrc: contains aliases (convenience shortcuts)
 # - exchange.sh: commands to run at container boot for Exchange Django app
 # - worker.sh: commands to run at container boot for Exchange Celery app
 # - settings.sh: environment variables

--- a/docker/home/.bashrc
+++ b/docker/home/.bashrc
@@ -1,4 +1,0 @@
-alias django-runserver='/env/bin/python /mnt/exchange/manage.py runserver 0.0.0.0:8000'
-alias django-celeryworker='/env/bin/python /mnt/exchange/manage.py celery worker -E --loglevel=DEBUG'
-alias django-collectstatic='/env/bin/python /mnt/exchange/manage.py collectstatic'
-alias django-migrate='/env/bin/python /mnt/exchange/manage.py migrate'


### PR DESCRIPTION
The aliases are left intact in the Vagrant config, which is not touched.

I originally included these for continuity with the vagrant config, but in the docker config I don't think these are needed at all and are only going to cause confusion. 