### PR TITLE
Update GeoServer WAR for Vagrant and Docker to use 2.9 image with GGig 1.0-RC3 plugin

### DIFF
--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -102,7 +102,7 @@ geoserver_setup()
     if [ ! -f /vagrant/dev/.geoserver/geoserver.war ]; then
 	    echo "=> Downloading GeoServer web archive"
 	    pushd /vagrant/dev/.geoserver
-	    wget https://s3.amazonaws.com/boundlessps-public/mapstory/rc1a/geoserver.war > /dev/null 2>&1
+	    wget https://s3.amazonaws.com/boundlessps-public/GVS/geoserver.war > /dev/null 2>&1
 	    unzip geoserver.war -d geoserver
 	    popd
     fi

--- a/docker/geoserver/Dockerfile
+++ b/docker/geoserver/Dockerfile
@@ -4,7 +4,7 @@ FROM tomcat:9-jre8
 
 # Grab the WAR file containing the version of GeoServer Exchange depends on.
 # Avoid ADD so we can reuse this layer instead of downloading at every build.
-RUN wget --directory-prefix /tmp --progress=dot:giga https://s3.amazonaws.com/boundlessps-public/mapstory/rc1a/geoserver.war
+RUN wget --directory-prefix /tmp --progress=dot:giga https://s3.amazonaws.com/boundlessps-public/GVS/geoserver.war
 
 # Run config inside container
 RUN unzip -o /tmp/geoserver.war -d /tmp/geoserver && \


### PR DESCRIPTION
Update the Vagrant bootstrap.sh and Docker files to use the GeoServer 2.9 image that contains the latest released GeoGig plugin version 1.0-RC3