### PR TITLE
use initial.json instead of initial_data

### DIFF
--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -73,7 +73,7 @@ exchange_setup()
     python /vagrant/manage.py migrate --noinput
     python /vagrant/manage.py collectstatic --noinput
     #hotfix, need to find out why it is not importing the categories
-    python /vagrant/manage.py loaddata initial_data
+    python /vagrant/manage.py loaddata initial
     #echo "from geonode.people.models import Profile; Profile.objects.create_superuser('admin', 'admin@exchange.com', 'exchange', first_name='Administrator', last_name='Exchange')" | python /vagrant/manage.py shell
     #echo "from geonode.people.models import Profile; Profile.objects.create_user('test', 'test@exchange.com', 'exchange', first_name='Test', last_name='User')" | python /vagrant/manage.py shell
     printf "\nsource /vagrant/dev/activate\n" > /home/vagrant/.bash_profile

--- a/docker/home/common.sh
+++ b/docker/home/common.sh
@@ -177,7 +177,7 @@ run_migrations () {
         log "Collecting static assets ..."
         $manage collectstatic --noinput
         # "hotfix, need to find out why it is not importing the categories"
-        $manage loaddata initial_data
+        $manage loaddata initial
     else
         log "POSTGIS_URL is not set, so migrations cannot run"
         exit 1


### PR DESCRIPTION
There was a reason why initial_data.json was renamed to initial.json:
initial_data is autoloaded every time migrations are run, which was causing
some data to be lost: in thi scase, it would switch to the default template,
when some deploys for clients had another template.
(Django is deprecating that automagic soon anyway, but we didn't want it here.)

However, we do still want to load that data in a new instance, hence
this commit. Just renaming initial_data to initial left new dev instances in
a dumb state (e.g.: ValueError at /account/login/ - The 'logo_image' attribute
has no file associated with it.)

Unfortunately, ./manage.py loaddata some_invalid_fixture_name actually
runs with exit code 0, so the scripts weren't halting as they should have
in order to highlight the problem, but what can you do