### PR TITLE
stub .bashrc so docker exec shells don't exit on every error

### DIFF
--- a/docker/home/.bashrc
+++ b/docker/home/.bashrc
@@ -1,0 +1,6 @@
+# Source CentOS configs
+if [ -f /etc/bashrc ]; then
+  . /etc/bashrc
+fi
+# Don't exit the interactive shell (i.e. docker exec session) on first error
+set +e


### PR DESCRIPTION
apparently the removal of .bashrc causes docker exec shells to do the familiar behavior of killing the shell any time a command is issued which exits with an error code.

(btw, set -e might be involved in the behavior we see in the Vagrant environment, but I don't have all day to experiment with it)