### PR TITLE
vagrant, docker: extra migrate account for DoesNotExist profile issue

### DIFF
--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -74,6 +74,9 @@ exchange_setup()
     python /vagrant/manage.py collectstatic --noinput
     #hotfix, need to find out why it is not importing the categories
     python /vagrant/manage.py loaddata initial
+    # migrate account after loaddata to avoid DoesNotExist profile issue
+    python /vagrant/manage.py migrate account --noinput
+
     #echo "from geonode.people.models import Profile; Profile.objects.create_superuser('admin', 'admin@exchange.com', 'exchange', first_name='Administrator', last_name='Exchange')" | python /vagrant/manage.py shell
     #echo "from geonode.people.models import Profile; Profile.objects.create_user('test', 'test@exchange.com', 'exchange', first_name='Test', last_name='User')" | python /vagrant/manage.py shell
     printf "\nsource /vagrant/dev/activate\n" > /home/vagrant/.bash_profile

--- a/docker/home/common.sh
+++ b/docker/home/common.sh
@@ -178,6 +178,8 @@ run_migrations () {
         $manage collectstatic --noinput
         # "hotfix, need to find out why it is not importing the categories"
         $manage loaddata initial
+        # migrate account after loaddata to avoid DoesNotExist profile issue
+        $manage migrate account --noinput
     else
         log "POSTGIS_URL is not set, so migrations cannot run"
         exit 1


### PR DESCRIPTION
Dan's suggested workaround which will hopefully not break when GeoNode lands a PR to fix migration dependency ordering issues.

Locally working against both vagrant and docker on exchange master.