### PR TITLE
[1.0.2] Switch to django-registry==0.3.11 and pycsw==2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ elasticsearch==1.9.0
 pylibmc==1.5.1
 mapproxy==1.9.0
 djmp==0.2.8
-django-registry==0.3.9
+django-registry==0.3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # GeoNode is now using >= and <= in setup.py, if you need specific versions,
 # they should be listed in this file.
 git+git://github.com/boundlessgeo/django-exchange-maploom.git@5722937aba061ddcf3bd2c7b31d6cd616bafbbd9#egg=django-maploom
-git+git://github.com/geopython/pycsw.git@2.0#egg=pycsw
+pycsw==2.0.1
 geonode==2.5.2
 dj-database-url==0.4.1
 django-storages==1.1.8
@@ -30,4 +30,4 @@ elasticsearch==1.9.0
 pylibmc==1.5.1
 mapproxy==1.9.0
 djmp==0.2.8
-django-registry==0.3.10
+django-registry==0.3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # GeoNode is now using >= and <= in setup.py, if you need specific versions,
 # they should be listed in this file.
 git+git://github.com/boundlessgeo/django-exchange-maploom.git@5722937aba061ddcf3bd2c7b31d6cd616bafbbd9#egg=django-maploom
-git+git://github.com/geopython/pycsw.git@4fc1fc1eee3ac4b83d2862d311b20efb142e13bd#egg=pycsw
+git+git://github.com/geopython/pycsw.git@2.0#egg=pycsw
 geonode==2.5.2
 dj-database-url==0.4.1
 django-storages==1.1.8
@@ -30,4 +30,4 @@ elasticsearch==1.9.0
 pylibmc==1.5.1
 mapproxy==1.9.0
 djmp==0.2.8
-django-registry==0.3.6
+django-registry==0.3.9


### PR DESCRIPTION
The main goal of this version is to support a CSW-T workflow, it has been tested with the RIO Foundation Layers from NGA while maintaining the ability to harvest records.

## Changelog

Version 0.3.11

 - Elasticsearch 1.7 compatibility.
 - CSW-T Insert support with custom <registry> tags.
 - Custom <registry> tags available in MapLoom UI.
 - Full screen MapLoom Registry modal.
 - Adaptive pagination based on available height.
 - Fixed MapProxy issues with WMS servers. workspace:name is now sent as layer name instead of name.
 - Fixed map display issues on hover for ArcGIS layers.
 - is_monitored is set to False on services uploaded via CSW-T.
 - Added users, admins and developers documentation.
 - More robust parsing of ArcGIS services url.
 - Switched to q.param and a.param instead of a_param and q_param for future compatibility with angular-search.
 - Added uuid field, requires migrations.

## Known Issues in version 0.3.11

 - Items from Brazil can appear in Australia: https://github.com/cga-harvard/HHypermap/issues/199
 - Service name is not set up properly when ingesting via CSW-T: https://github.com/cga-harvard/HHypermap/issues/200
 - Some bounding boxes are advertised as EPSG:4326 but have values in an invalid range: https://github.com/cga-harvard/HHypermap/issues/192
 - Service and Layer checks can cause overload on remote servers. Checks should not be so exhaustive. https://github.com/cga-harvard/HHypermap/issues/173
 - Last check date is not being reported, last modification date is being reported instead. https://github.com/cga-harvard/HHypermap/issues/201
 - Sibling services are being imported in ArcGIS services: https://github.com/cga-harvard/HHypermap/issues/203

## Notes

This should be pulled with a MapLoom version that contains this change: https://github.com/boundlessgeo/MapLoom/pull/32