### PR TITLE
Change wrapper and page title margin so content is always visible.

### DIFF
--- a/exchange/static/css/site_base.css
+++ b/exchange/static/css/site_base.css
@@ -46,10 +46,13 @@ a:hover{
 #wrap {
   height: auto !important;
   height: 100%;
-  padding: 10px 0 60px;
+  padding: 50px 0 60px;
   margin-bottom: -70px;
   min-height: 100%;
   background: #E6E9ED;
+}
+.page-header {
+  margin: 0 0 20px;
 }
 nav.filter h4 {
   border-radius: 3px;


### PR DESCRIPTION
JIRA: https://issues.boundlessgeo.com:8443/browse/NODE-379

Depending on page content (and whether `.page-header` appears on the first `div`), spacing between the nav area and the page content is inconsistent, so things like alerts were not always visible and sometimes were obscured by the navigation.

This fix applies consistent padding under the nav on `#wrap` so that no content can be hidden by the navigation. It also removes margin that was applied to `.page-header` so that we're not getting a double height of spacing below alerts and other UI elements that appear before `.page-header`s. Screen shots below confirm that the change in appearance to pages using `.page-header` is minimal.

## Before
![screen shot 2016-09-06 at 4 23 33 pm](https://cloud.githubusercontent.com/assets/1529366/18291580/6d9e5332-744e-11e6-808e-af568828392f.png)
![screen shot 2016-09-06 at 4 24 06 pm](https://cloud.githubusercontent.com/assets/1529366/18291581/6d9f7df2-744e-11e6-956f-55b900ca5447.png)

## After
![screen shot 2016-09-06 at 4 20 29 pm](https://cloud.githubusercontent.com/assets/1529366/18291586/75e0d736-744e-11e6-8a7f-64da3c6363bb.png)
![screen shot 2016-09-06 at 4 20 16 pm](https://cloud.githubusercontent.com/assets/1529366/18291587/75e9dc0a-744e-11e6-8a03-de8237e04f31.png)
