### PR TITLE
avoid empty dd tags in metadata detail templates

### DIFF
--- a/exchange/templates/layers/metadata_detail.html
+++ b/exchange/templates/layers/metadata_detail.html
@@ -113,33 +113,33 @@
     <dl class="dl-horizontal">
 
         {% if layer.owner %}
-        {% with layer.owner as poc %}
+        {% with poc=layer.owner NO_VALUE="None" %}
 
         <dt>{% trans "Name" %}</dt>
-        <dd>{{ poc.name_long }}</dd>
+        <dd>{{ poc.name_long|default:NO_VALUE }}</dd>
 
         <dt>{% trans "email" %}</dt>
-        <dd>{{ poc.email }}</dd>
+        <dd>{{ poc.email|default:NO_VALUE }}</dd>
 
         <dt>{% trans "Position" %}</dt>
-        <dd>{{ poc.position }}</dd>
+        <dd>{{ poc.position|default:NO_VALUE }}</dd>
 
         <dt>{% trans "Organization" %}</dt>
-        <dd>{{ poc.organization }}</dd>
+        <dd>{{ poc.organization|default:NO_VALUE }}</dd>
 
         <dt>{% trans "Location" %}</dt>
-        <dd>{{ poc.location }}</dd>
+        <dd>{{ poc.location|default:NO_VALUE }}</dd>
 
         <dt>{% trans "Voice" %}</dt>
-        <dd>{{ poc.voice }}</dd>
+        <dd>{{ poc.voice|default:NO_VALUE }}</dd>
 
         <dt>{% trans "Fax" %}</dt>
-        <dd>{{ poc.fax }}</dd>
+        <dd>{{ poc.fax|default:NO_VALUE }}</dd>
 
         {% if poc.keyword_list %}
         <dt>{% trans "Keywords" %}</dt>
         <dd>{% for keyword in poc.keyword_list %}
-            {{ keyword }}
+            {{ keyword|default:NO_VALUE }}
             {% endfor %}</dd>
         {% endif %}
 

--- a/exchange/templates/maps/metadata_detail.html
+++ b/exchange/templates/maps/metadata_detail.html
@@ -113,33 +113,33 @@
     <dl class="dl-horizontal">
 
         {% if layer.owner %}
-        {% with layer.owner as poc %}
+        {% with poc=layer.owner NO_VALUE="None" %}
 
         <dt>{% trans "Name" %}</dt>
-        <dd>{{ poc.name_long }}</dd>
+        <dd>{{ poc.name_long|default:NO_VALUE }}</dd>
 
         <dt>{% trans "email" %}</dt>
-        <dd>{{ poc.email }}</dd>
+        <dd>{{ poc.email|default:NO_VALUE }}</dd>
 
         <dt>{% trans "Position" %}</dt>
-        <dd>{{ poc.position }}</dd>
+        <dd>{{ poc.position|default:NO_VALUE }}</dd>
 
         <dt>{% trans "Organization" %}</dt>
-        <dd>{{ poc.organization }}</dd>
+        <dd>{{ poc.organization|default:NO_VALUE }}</dd>
 
         <dt>{% trans "Location" %}</dt>
-        <dd>{{ poc.location }}</dd>
+        <dd>{{ poc.location|default:NO_VALUE }}</dd>
 
         <dt>{% trans "Voice" %}</dt>
-        <dd>{{ poc.voice }}</dd>
+        <dd>{{ poc.voice|default:NO_VALUE }}</dd>
 
         <dt>{% trans "Fax" %}</dt>
-        <dd>{{ poc.fax }}</dd>
+        <dd>{{ poc.fax|default:NO_VALUE }}</dd>
 
         {% if poc.keyword_list %}
         <dt>{% trans "Keywords" %}</dt>
         <dd>{% for keyword in poc.keyword_list %}
-            {{ keyword }}
+            {{ keyword|default:NO_VALUE }}
             {% endfor %}</dd>
         {% endif %}
 


### PR DESCRIPTION
When values like email and location were empty strings (possibly because they have string type in the database), the template was rendering <dd></dd>, which meant that all the other <dd> elements were pushing up the page, along with the following span.subtitle.

Why fix this at the Django template level?

1. It doesn't seem useful, and will introduce other complications, to ensure the database has NULLs or that we intervene at the Python level (before template rendering) to translate null strings into None.

2. We probably either want to delete both dt and dd, or to explicitly indicate to user that there is no value. So if in the future there is a solution which doesn't require adding presentation-only classes to dd tags, that could be worth taking, but we still need the template-level fix.