### PR TITLE
MapLoom update to use swagger api for registry + v1.0.2 updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # TODO: Make sure requirements.txt are complete for exchange's env.
 # GeoNode is now using >= and <= in setup.py, if you need specific versions,
 # they should be listed in this file.
-git+git://github.com/boundlessgeo/django-exchange-maploom.git@5722937aba061ddcf3bd2c7b31d6cd616bafbbd9#egg=django-maploom
+git+git://github.com/boundlessgeo/django-exchange-maploom.git@v1.5.10#egg=django-maploom
 git+git://github.com/geopython/pycsw.git@4fc1fc1eee3ac4b83d2862d311b20efb142e13bd#egg=pycsw
 geonode==2.5.2
 dj-database-url==0.4.1


### PR DESCRIPTION
Of the 1.0.2 registry updates this will be the only change to master. In the future there should not be any additional updates to MapLoom in regards to registry, since it now pulls data via an api. 

The reason why this will be the only change is that in the next release we will be adding a PR soon to remove registry from exchange and install it separetly in the rpm. A separate branch v1.0.2 has been created that includes the new registry changes. This maploom version has been tested in client environment.

