### PR TITLE
make dev nginx accept absurdly large uploads for testing

### DIFF
--- a/docker/nginx/exchange.conf
+++ b/docker/nginx/exchange.conf
@@ -1,4 +1,5 @@
 server {
+    client_max_body_size 1000M;
 
     listen  80;
     server_name _;


### PR DESCRIPTION
When using the docker dev environment, we need to be able to upload files to Exchange that are bigger than the rather small default size limit set by the nginx that is proxying to Exchange.

This is an internal need that does not have a specific JIRA story, but it arose while trying to test NODE-362. Also, there have been some recent mentions of Exchange's behavior with larger datasets in connection to GeoGig. So this issue will come up and we might as well have this done in advance since it's so trivial