### PR TITLE
expose INSTALLED_APPS from resource_variables

### DIFF
--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -32,6 +32,7 @@ def resource_variables(request):
         MAP_CRS=settings.DEFAULT_MAP_CRS,
         BOUNDLESS_URL=settings.BOUNDLESS_URL,
         BOUNDLESS_LINKTEXT=settings.BOUNDLESS_LINKTEXT,
+        INSTALLED_APPS=set(settings.INSTALLED_APPS),
     )
 
     return defaults


### PR DESCRIPTION
This is for consumption by templates e.g. from osgeo_importer.