### PR TITLE
remove *.pyc preventively during container boot

### DIFF
--- a/docker/home/common.sh
+++ b/docker/home/common.sh
@@ -194,3 +194,7 @@ started () {
     log "${name}: stopping"
     exit "${status}"
 }
+
+remove_pycs () {
+    find /mnt/exchange -type f -name "*.pyc" -delete
+}

--- a/docker/home/exchange.sh
+++ b/docker/home/exchange.sh
@@ -32,6 +32,11 @@ log "Starting Exchange"
 # since it is easy to forget or mess up.
 check_mounts
 
+# Clean up *.pyc files which can throw a monkey wrench in the works these can
+# persist or transfer between docker/vagrant envs due to the use of mounted
+# directories.
+remove_pycs
+
 # Set environment variables
 load_settings
 


### PR DESCRIPTION
The recent PR removing files like exchange/core/admin.py may cause any remaining *.pyc files still present in the Exchange working tree to be imported (via mounts) in the docker container, causing mayhem. Same may happen in future changes as well. This automates the cleanup to prevent that.

Wouldn't be an issue except for the use of mounts, which is hard to do away with