### PR TITLE
Exchange release 1.1.0rc1

### DIFF
--- a/exchange/__init__.py
+++ b/exchange/__init__.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     pass
 
-__version__ = (1, 0, 1, 'rc', 0)
+__version__ = (1, 1, 0, 'rc', 1)
 
 
 def get_version():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,6 @@
 --index-url https://pypi.python.org/simple/
 
-
-# TODO: Make sure requirements.txt are complete for exchange's env.
-# GeoNode is now using >= and <= in setup.py, if you need specific versions,
-# they should be listed in this file.
-git+git://github.com/boundlessgeo/django-exchange-maploom.git@v1.5.11#egg=django-exchange-maploom
+django-exchange-maploom==1.5.11
 geonode==2.5.5
 dj-database-url==0.4.1
 django-storages==1.1.8
@@ -20,9 +16,8 @@ python-ldap==2.4.25
 django-auth-ldap==1.2.7
 GDAL==2.0.1
 supervisor==3.2.3
-gunicorn==19.4.5
 python-resize-image==1.1.10
 django-flat-theme==1.1.3
-git+git://github.com/boundlessgeo/django-exchange-themes@master#egg=appearance
-git+git://github.com/boundlessgeo/django-osgeo-importer@b77ea961ea458b9c2ed8388ce7011a43e29f6fe9#egg=django-osgeo-importer
+django-exchange-themes==1.0.1
 django-exchange-docs==1.1.0
+git+git://github.com/boundlessgeo/django-osgeo-importer@b77ea961ea458b9c2ed8388ce7011a43e29f6fe9#egg=django-osgeo-importer

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,25 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        # see requirements.txt
+        "django-exchange-maploom==1.5.11",
+        "geonode==2.5.5",
+        "dj-database-url==0.4.1",
+        "django-storages==1.1.8",
+        "boto==2.38.0",
+        "waitress==0.9.0",
+        "whitenoise==3.2",
+        "django-cors-headers==1.1.0",
+        "django-classification-banner==0.1.5",
+        "django-solo==1.1.2",
+        "django-colorfield==0.1.10",
+        "psycopg2==2.6.1",
+        "python-ldap==2.4.25",
+        "django-auth-ldap==1.2.7",
+        "GDAL==2.0.1",
+        "supervisor==3.2.3",
+        "python-resize-image==1.1.10",
+        "django-flat-theme==1.1.3",
+        "django-exchange-themes==1.0.1",
+        "django-exchange-docs==1.1.0"
     ]
 )


### PR DESCRIPTION
- Updated version to 1.1.0c1
- Removed gunicorn as a dependency from exchange
- set versions for django-exchange-maploom and django-exchange-themes
- removed TODO section from requirements.txt
- added set versions for 1.1.0rc1 release in the install_requires section of setup.py