### PR TITLE
Issue when using exchange as a package

### DIFF
--- a/exchange/__init__.py
+++ b/exchange/__init__.py
@@ -18,11 +18,6 @@
 #
 #########################################################################
 
-try:
-    from celery_app import app as celery_app  # flake8: noqa
-except ImportError:
-    pass
-
 __version__ = (1, 1, 0, 'rc', 1)
 
 


### PR DESCRIPTION
- when importing exchange.settings the init was causing an error when trying to `from celery_app import app as celery_app`, since the settings had not been set for django.conf.