### PR TITLE
TEMPORARY shim to resolve celery issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 
 django-exchange-maploom==1.5.11
 geonode==2.5.5
+celery==3.1.17
 dj-database-url==0.4.1
 django-storages==1.1.8
 boto==2.38.0


### PR DESCRIPTION
Reference: https://github.com/boundlessgeo/exchange/pull/104, https://github.com/GeoNode/geonode/issues/2700

This is just an ugly, **temporary** fix to get Travis CI up & running again. Should be removed once Travis is modified to pull deps from GeoNode's requirements.txt