### PR TITLE
Fixing Postgres 9.5 + PostGIS on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ services:
 
 addons:
   postgresql: "9.5"
+  apt:
+    packages:
+    - postgresql-9.5-postgis-2.3
 
 # branches:
 #   only:


### PR DESCRIPTION
The Dec 1 update to Travis CI broke postgis with postgresql 9.5. See https://travis-ci.org/boundlessgeo/exchange/builds/181781483#L435.

Some related issues & discussion:

https://github.com/travis-ci/travis-ci/issues/5509
https://github.com/travis-ci/travis-ci/issues/4264
https://github.com/travis-ci/travis-ci/issues/6972

This is one possible solution. We'll see if it works.

~*DO NOT MERGE* - testing Travis.~ Yep, this works. Safe to merge once CI completes.