### PR TITLE
Disabling registry services by default

### DIFF
--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -27,6 +27,7 @@ def resource_variables(request):
     defaults = dict(
         VERSION=get_version(),
         REGISTRYURL=getattr(settings, 'REGISTRYURL', None),
+        REGISTRY=getattr(settings, 'REGISTRY', False),
         MAP_CRS=settings.DEFAULT_MAP_CRS,
         INSTALLED_APPS=set(settings.INSTALLED_APPS),
     )

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -375,7 +375,7 @@ if GEOAXIS_ENABLED:
 
 
 # NEED TO UPDATE DJANGO_MAPLOOM FOR ONLY THIS ONE VALUE
-REGISTRY = os.environment.get('ENABLE_REGISTRY', False)
+REGISTRY = os.environ.get('ENABLE_REGISTRY', False)
 REGISTRYURL = os.environ.get('REGISTRYURL', None)
 REGISTRY_CAT = os.environ.get('REGISTRY_CAT', 'registry')
 

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -375,6 +375,7 @@ if GEOAXIS_ENABLED:
 
 
 # NEED TO UPDATE DJANGO_MAPLOOM FOR ONLY THIS ONE VALUE
+REGISTRY = os.environment.get('ENABLE_REGISTRY', False)
 REGISTRYURL = os.environ.get('REGISTRYURL', None)
 REGISTRY_CAT = os.environ.get('REGISTRY_CAT', 'registry')
 

--- a/exchange/templates/people/profile_detail.html
+++ b/exchange/templates/people/profile_detail.html
@@ -139,7 +139,7 @@
     </ul>
       {% if user.is_superuser %}
     <ul class="list-group">
-      {% if not REGISTRYURL %}
+      {% if not REGISTRYURL and REGISTRY %}
       <li class="list-group-item"><a href="{% url "services" %}"><i class="fa fa-globe"></i> {% trans "Remote Services" %}</a></li>
       {% endif %}
       <li class="list-group-item"><a href="{% url "account_invite_user" %}"><i class="fa fa-edit"></i> {% trans "Invite User" %}</a></li>

--- a/exchange/urls.py
+++ b/exchange/urls.py
@@ -25,6 +25,7 @@ from django.contrib.auth.decorators import login_required
 from maploom.geonode.urls import urlpatterns as maploom_urls
 from geonode.urls import urlpatterns as geonode_urls
 from . import views
+from django.views.defaults import page_not_found
 
 js_info_dict = {
     'packages': ('geonode.layers',),
@@ -46,6 +47,11 @@ urlpatterns = patterns(
     url(r'^csw/status/$', views.csw_status, name='csw_status'),
     url(r'^csw/status_table/$', views.csw_status_table, name='csw_status_table'),
 )
+
+if settings.REGISTRY is False:
+    urlpatterns += [
+        url(r'^services(.*)$', page_not_found)
+    ]
 
 # If django-osgeo-importer is enabled...
 if 'osgeo_importer' in settings.INSTALLED_APPS:


### PR DESCRIPTION
This is a redo of PR #103 which should prevent the user from being able to use registry services by default in Exchange. They can be enabled by setting the `REGISTRY` variable to `True`.

Although it is not visible, this same variable is present in MapLoom. By setting it to False, it should prevent the error state from being reachable in MapLoom as well.

Therefore:
- Setting the REGISTRY variable in Exchange's settings to False prevents a potential error state in MapLoom
- We can also leverage the REGISTRY settings variable to block the endpoint in Exchange, so the user cannot use functionality that they won't be able to access in MapLoom anyway