### PR TITLE
NODE-634 setup to use new geonode/geoserver oauth2 configuration

### DIFF
--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -99,9 +99,9 @@ exchange_setup()
     python /vagrant/manage.py loaddata base_resources
     # migrate account after loaddata to avoid DoesNotExist profile issue
     python /vagrant/manage.py migrate account --noinput
+    # load default_oauth_apps fixture from geonode
+    python /vagrant/manage.py loaddata default_oauth_apps
 
-    #echo "from geonode.people.models import Profile; Profile.objects.create_superuser('admin', 'admin@exchange.com', 'exchange', first_name='Administrator', last_name='Exchange')" | python /vagrant/manage.py shell
-    #echo "from geonode.people.models import Profile; Profile.objects.create_user('test', 'test@exchange.com', 'exchange', first_name='Test', last_name='User')" | python /vagrant/manage.py shell
     printf "\nsource /vagrant/dev/activate\n" > /home/vagrant/.bash_profile
     if ! grep -q 'django-runserver' /home/vagrant/.bashrc; then
         printf "\nalias django-runserver='/vagrant/.venv/bin/python /vagrant/manage.py runserver 0.0.0.0:8000'" >> /home/vagrant/.bashrc

--- a/docker/geoserver/Dockerfile
+++ b/docker/geoserver/Dockerfile
@@ -12,6 +12,10 @@ RUN unzip -o /tmp/geoserver.war -d /tmp/geoserver && \
                /tmp/geoserver/data/security/auth/geonodeAuthProvider/config.xml && \
     sed -i.bak 's@<onlineResource>http://geoserver.org</onlineResource>@<onlineResource>http://geoserver.org</onlineResource><proxyBaseUrl>http://172.16.238.2/geoserver/</proxyBaseUrl>@' \
                /tmp/geoserver/data/global.xml && \
+    sed -i.bak 's@localhost:\(8000\|8080\)@172.16.238.2@g' \
+               /tmp/geoserver/data/security/filter/geonode-oauth2/config.xml && \
+    sed -i.bak 's@localhost:8000@172.16.238.2@g' \
+               /tmp/geoserver/data/security/role/geonode\ REST\ role\ service/config.xml && \
     rm -rf /usr/local/tomcat/webapps/geoserver && \
     mv /tmp/geoserver $CATALINA_HOME/webapps/geoserver && \
     chmod -R 755 $CATALINA_HOME/webapps/geoserver && \

--- a/docker/home/common.sh
+++ b/docker/home/common.sh
@@ -189,6 +189,8 @@ run_migrations () {
         $manage loaddata base_resources
         # migrate account after loaddata to avoid DoesNotExist profile issue
         $manage migrate account --noinput
+        # load docker_oauth_apps fixture
+        $manage loaddata /mnt/exchange/docker/home/docker_oauth_apps.json
     else
         log "POSTGIS_URL is not set, so migrations cannot run"
         exit 1

--- a/docker/home/docker_oauth_apps.json
+++ b/docker/home/docker_oauth_apps.json
@@ -1,0 +1,18 @@
+[
+{
+    "model": "oauth2_provider.application",
+    "pk": 1001,
+    "fields": {
+        "skip_authorization": true,
+        "redirect_uris": "http://172.16.238.2/geoserver/geoserver",
+        "name": "GeoServer",
+        "authorization_grant_type": "authorization-code",
+        "client_type": "confidential",
+        "client_id": "Jrchz2oPY3akmzndmgUTYrs9gczlgoV20YPSvqaV",
+        "client_secret": "rCnp5txobUo83EpQEblM8fVj3QT5zb5qRfxNsuPzCqZaiRyIoxM4jdgMiZKFfePBHYXCLd7B8NlkfDBY9HKeIQPcy5Cp08KQNpRHQbjpLItDHv12GvkSeXp6OxaUETv3",
+        "user": [
+            "admin"
+        ]
+    }
+}
+]

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -120,6 +120,9 @@ INSTALLED_APPS = (
     'exchange-docs',
 ) + INSTALLED_APPS
 
+# authorized exempt urls
+AUTH_EXEMPT_URLS = ('/api/o/*', '/api/roles', '/api/adminRole', '/api/users',)
+
 # geoserver settings
 GEOSERVER_URL = os.environ.get(
     'GEOSERVER_URL',
@@ -152,6 +155,8 @@ OGC_SERVER = {
     'default': {
         'BACKEND': 'geonode.geoserver',
         'LOCATION': GEOSERVER_URL,
+        'LOGIN_ENDPOINT': 'j_spring_oauth2_geonode_login',
+        'LOGOUT_ENDPOINT': 'j_spring_oauth2_geonode_logout',
         'PUBLIC_LOCATION': GEOSERVER_URL,
         'USER': GEOSERVER_USER,
         'PASSWORD': GEOSERVER_PASSWORD,

--- a/exchange/themes/migrations/0003_auto_20170104_0910.py
+++ b/exchange/themes/migrations/0003_auto_20170104_0910.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import exchange.themes.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('themes', '0002_auto_20160918_2121'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='theme',
+            name='hyperlink_hex',
+        ),
+        migrations.AddField(
+            model_name='theme',
+            name='running_link_hex',
+            field=exchange.themes.fields.ColorField(default=b'29748F', max_length=7, null=True, verbose_name=b'Header Footer Link Color', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='theme',
+            name='background_logo',
+            field=models.ImageField(default=None, upload_to=b'theme/img/', blank=True, help_text=b'Note: will resize to width 1440px and height 350px', null=True, verbose_name=b'Background Image'),
+        ),
+        migrations.AlterField(
+            model_name='theme',
+            name='docs_text',
+            field=models.CharField(default=b'Documentation', max_length=32, blank=True, help_text=b'Text for the documentation link', null=True, verbose_name=b'Footer Documentation Text'),
+        ),
+    ]


### PR DESCRIPTION
Automated the configuration for [geoserver_geonode_security](http://docs.geonode.org/en/latest/tutorials/admin/geoserver_geonode_security/index.html) both Docker and Vagrant (RPMS will need adjustment via the spec file)

- added a specific fixture for oauth2_providor (Docker)
- added new additions for login and logout endpoints to `OGC_SERVER` dictionary.  (All deployments)
- added required `AUTH_EXEMPT_URLS` that are required for geoserver oauth extension to communicate to geonode auth api when `LOCKDOWN_GEONODE` is set to True. (All deployments)
- now loads the docker_oauth_apps fixture during the execution of the common.sh (Docker)
- added some sed statements to allow for an automated deployment of geoserver with an oauth config to exchange docker setup. (Docker)
- now loads the default oauth_apps fixture from geonode. (Vagrant)
Note: The vagrant setup doesnt need to have any sed statements to adjust files in the geoserver data directory, because the default localhost will work.
- added migration that was added when running makemigrations for the addition of the themes app. (All deployments)