### PR TITLE
Pin dev-only dependency on osgeo-importer to upstream master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,7 @@ RUN PATH=$PATH:/usr/pgsql-9.6/bin && /env/bin/pip install -r /mnt/exchange/requi
     /env/bin/pip uninstall -y GeoNode
 
 # Moving osgeo-importer to Docker because it's a dev only dependency at the moment
-# Using commit 930c68a to solve https://github.com/boundlessgeo/exchange/issues/127
-RUN /env/bin/pip install git+git://github.com/GeoNode/django-osgeo-importer@930c68abe3bc392282d5fe3f5e3786bb96c8bdd9#egg=django-osgeo-importer
+RUN /env/bin/pip install git+git://github.com/GeoNode/django-osgeo-importer@master#egg=django-osgeo-importer
 
 # docker/home contains a number of things that will go in $HOME:
 # - local_settings.py: env-specific monkeypatches for django's settings.py


### PR DESCRIPTION
There's no longer a need to pin importer to an older commit during dev: pip installing current upstream master is confirmed to work as expected.

Ref: NODE-633