### PR TITLE
Use boundless-vendor-libs rpm and remove upstream requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
   # Install Java, Jetty and Geoserver
   - sudo apt-get -qq install openjdk-8-jdk-headless
   - wget --directory-prefix=/tmp -q http://central.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.3.8.v20160314/jetty-runner-9.3.8.v20160314.jar
-  - wget --directory-prefix /tmp -q https://s3.amazonaws.com/boundlessps-public/GVS/geoserver.war
+  - wget --directory-prefix /tmp -q https://exchange-development-war.s3.amazonaws.com/war/geoserver.war
   - unzip -qq -o /tmp/geoserver.war -d /tmp/geoserver
 
   - sed -i.bak 's@<baseUrl>\([^<][^<]*\)</baseUrl>@<baseUrl>http://localhost/</baseUrl>@' /tmp/geoserver/data/security/auth/geonodeAuthProvider/config.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,54 +12,42 @@ FROM centos:6.7
 # TODO: audit what is needed here or not
 RUN yum -y install https://s3.amazonaws.com/exchange-development-yum/exchange-development-repo-1.0.0.noarch.rpm
 RUN sed -i -e 's:keepcache=0:keepcache=1:' /etc/yum.conf && \
-    yum -y install https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm && \
     yum update -y && \
-    yum -y install \
-        # for pip install from git URLs
-        git \
-        # headers
-        python27-devel \
-        # create virtualenv
-        python27-virtualenv \
-        # compile C extensions
-        gcc \
-        gcc-c++ \
-        make \
-        expat-devel \
-        db4-devel \
-        gdbm-devel \
-        sqlite-devel \
-        readline-devel \
-        zlib-devel \
-        bzip2-devel \
-        openssl-devel \
-        tk-devel \
-        gdal-devel-2.1.2 \
-        libxslt-devel \
-        libxml2-devel \
-        libjpeg-turbo-devel \
-        zlib-devel \
-        libtiff-devel \
-        freetype-devel \
-        lcms2-devel \
-        proj-devel \
-        geos-devel \
-        # Headers for pip install psycopg2
-        postgresql96-devel \
-        openldap-devel \
-        libmemcached-devel \
+    yum -y install boundless-vendor-libs \
+                   bzip2-devel \
+                   db4-devel \
+                   expat-devel \
+                   freetype-devel \
+                   gcc \
+                   gcc-c++ \
+                   gdbm-devel \
+                   git \
+                   libjpeg-turbo-devel \
+                   libmemcached-devel \
+                   libtiff-devel \
+                   libxml2-devel \
+                   libxslt-devel \
+                   make \
+                   openldap-devel \
+                   openssl-devel \
+                   python27-devel \
+                   python27-virtualenv \
+                   readline-devel \
+                   sqlite-devel \
+                   tk-devel \
+                   zlib-devel \
     && \
     # Create the virtualenv the app will run in
     /usr/local/bin/virtualenv /env && chmod -R 755 /env
 
 # Add Exchange requirements list to pip install during container build.
 # All work done AFTER this line will be re-done when requirements.txt changes.
-COPY requirements.txt /mnt/exchange/
+COPY requirements.txt /mnt/exchange/req.txt
 
-# Pre-install dependencies
-# Get preinstalled GeoNode out of the way so the mount can be used
-RUN PATH=$PATH:/usr/pgsql-9.6/bin && /env/bin/pip install -r /mnt/exchange/requirements.txt && \
-    /env/bin/pip uninstall -y GeoNode
+# install requirements after removing geonode entry
+RUN sed -i.bak "/egg=geonode/d" /mnt/exchange/req.txt && \
+    PATH="/opt/boundless/vendor/bin":"${PATH}" && \
+    /env/bin/pip install -r /mnt/exchange/req.txt
 
 # Moving osgeo-importer to Docker because it's a dev only dependency at the moment
 RUN /env/bin/pip install git+git://github.com/GeoNode/django-osgeo-importer@master#egg=django-osgeo-importer

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -10,50 +10,41 @@ FROM centos:6.7
 # Most of this is headers needed during pip install of Python packages with C.
 RUN sed -i -e 's:keepcache=0:keepcache=1:' /etc/yum.conf && \
     yum -y install https://s3.amazonaws.com/exchange-development-yum/exchange-development-repo-1.0.0.noarch.rpm && \
-    yum -y install https://yum.postgresql.org/9.6/redhat/rhel-6-x86_64/pgdg-centos96-9.6-3.noarch.rpm && \
-    yum -y install https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm && \
     yum update -y && \
-    yum -y install \
-        python27-devel \
-        python27-virtualenv \
-        gcc \
-        gcc-c++ \
-        make \
-        expat-devel \
-        db4-devel \
-        gdbm-devel \
-        sqlite-devel \
-        readline-devel \
-        zlib-devel \
-        bzip2-devel \
-        openssl-devel \
-        tk-devel \
-        gdal-devel-2.1.2 \
-        libxslt-devel \
-        libxml2-devel \
-        libjpeg-turbo-devel \
-        zlib-devel \
-        libtiff-devel \
-        freetype-devel \
-        lcms2-devel \
-        proj-devel \
-        geos-devel \
-        postgresql96-devel \
-        openldap-devel \
-        libmemcached-devel \
-        unzip \
-        wget \
-        git \
-        postgis2-96 \
-        elasticsearch \
-        rabbitmq-server-3.6.1
+    yum -y install boundless-vendor-libs \
+                   bzip2-devel \
+                   db4-devel \
+                   expat-devel \
+                   freetype-devel \
+                   gcc \
+                   gcc-c++ \
+                   gdbm-devel \
+                   git \
+                   libjpeg-turbo-devel \
+                   libtiff-devel \
+                   libxml2-devel \
+                   libxslt-devel \
+                   make \
+                   openldap-devel \
+                   openssl-devel \
+                   python27-devel \
+                   python27-virtualenv \
+                   readline-devel \
+                   sqlite-devel \
+                   tk-devel \
+                   unzip \
+                   wget \
+                   zlib-devel
 
-# Add the Exchange tree, install deps
+# Add the Exchange tree
 ADD . /opt/boundless/exchange
-RUN virtualenv /env && chmod -R 755 /env
-RUN PATH=$PATH:/usr/pgsql-9.6/bin && /env/bin/pip install -r /opt/boundless/exchange/requirements.txt > /dev/null
+RUN echo "GEOS_LIBRARY_PATH = '/opt/boundless/vendor/lib/libgeos_c.so'" >> /opt/boundless/exchange/exchange/settings/default.py
 
-# Travis can provide
+# Install deps
+RUN virtualenv /env && chmod -R 755 /env
+RUN PATH=$PATH:/opt/boundless/vendor/bin && /env/bin/pip install -r /opt/boundless/exchange/requirements.txt
+
+# Travis provides
 # PostGIS: https://docs.travis-ci.com/user/database-setup/#Using-PostGIS
 # RabbitMQ: https://docs.travis-ci.com/user/database-setup/#RabbitMQ
 # ElasticSearch: https://docs.travis-ci.com/user/database-setup/#ElasticSearch

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -19,9 +19,8 @@ gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
 " > /etc/yum.repos.d/elasticsearch.repo
 
     yum -y install https://s3.amazonaws.com/exchange-development-yum/exchange-development-repo-1.0.0.noarch.rpm
-    yum -y install https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
-
-    yum -y install python27-devel \
+    yum -y install boundless-vendor-libs \
+        python27-devel \
         python27-virtualenv \
         gcc \
         gcc-c++ \
@@ -35,17 +34,12 @@ gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
         bzip2-devel \
         openssl-devel \
         tk-devel \
-        gdal-devel-2.1.2 \
         libxslt-devel \
         libxml2-devel \
         libjpeg-turbo-devel \
         zlib-devel \
         libtiff-devel \
         freetype-devel \
-        lcms2-devel \
-        proj-devel \
-        geos-devel \
-        postgresql96-devel \
         openldap-devel \
         java-1.8.0-openjdk \
         unzip \
@@ -63,6 +57,7 @@ gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
     fi
     cp /vagrant/dev/settings.sh /etc/profile.d/settings.sh
     source /etc/profile.d/settings.sh
+    source /etc/profile.d/vendor-libs.sh
 }
 
 exchange_setup()

--- a/docker/home/common.sh
+++ b/docker/home/common.sh
@@ -48,7 +48,7 @@ echo_ip () {
 load_settings () {
     # Load variables into environment for Django app to consume
     source /etc/profile.d/settings.sh
-
+    source /etc/profile.d/vendor-libs.sh
     # Activate the virtualenv
     source /env/bin/activate
 
@@ -93,10 +93,10 @@ check_mounts () {
 }
 
 install_dependencies () {
+    # pin versions in exchange requirements that you will want to override
+    # exchange requirements are installed first with geonode removed. We will
+    # now install Geonode from local mount.
     # Unfortunately, this requires write access to $geonode_dir, because pip
-    # install -e insists on writing $geonode_dir/GeoNode.egg-info.
-    # But we still have to do it in order to ensure dependencies get in.
-    /env/bin/pip install --upgrade -r "${geonode_dir}/requirements.txt"
     /env/bin/pip install -e "${geonode_dir}"
 }
 
@@ -111,7 +111,7 @@ wait_for_pg () {
     for try in $(seq "$tries"); do
         sleep "${interval}"
         # Don't actually need to set username or db, just avoids error messages
-        if /usr/pgsql-9.6/bin/pg_isready --timeout="${timeout}" --host="${postgis_host}" --port="${postgis_port}" --dbname="${postgis_db}" --username="${postgis_username}" > /dev/null; then
+        if /opt/boundless/vendor/bin/pg_isready --timeout="${timeout}" --host="${postgis_host}" --port="${postgis_port}" --dbname="${postgis_db}" --username="${postgis_username}" > /dev/null; then
             started=1
             break
         # Check if host is unreachable
@@ -174,7 +174,6 @@ run_migrations () {
     local POSTGIS_URL="$(echo_postgis_url)"
 
     log "Running migrations against '${POSTGIS_URL}' ..."
-
     local manage='/env/bin/python /mnt/exchange/manage.py'
     if [ ! -z "${POSTGIS_URL}" ]; then
         pushd /mnt/exchange > /dev/null

--- a/docker/home/exchange.sh
+++ b/docker/home/exchange.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Include common variables and routines that are also used in worker.sh 
+# Include common variables and routines that are also used in worker.sh
 HERE=$(dirname $(readlink -f $0))
 source "${HERE}/common.sh"
-
+source "/etc/profile.d/vendor-libs.sh"
 # path to the log for this shell script - used by log() in common.sh
 readonly startup_log="/tmp/exchange_startup.log"
 

--- a/docker/home/local_settings.py
+++ b/docker/home/local_settings.py
@@ -1,3 +1,4 @@
 STATIC_ROOT = '/scratch/static_root'
 MEDIA_ROOT = '/scratch/media_root'
 ALLOWED_HOSTS = ["172.16.238.3", "exchange"]
+GEOS_LIBRARY_PATH = '/opt/boundless/vendor/lib/libgeos_c.so'

--- a/docker/home/worker.sh
+++ b/docker/home/worker.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Include common variables and routines that are also used in exchange.sh 
+# Include common variables and routines that are also used in exchange.sh
 HERE=$(dirname $(readlink -f $0))
 source "${HERE}/common.sh"
+source /etc/profile.d/vendor-libs.sh
 
 # path to the log for this shell script - used by log() in common.sh
 readonly startup_log="/tmp/worker_startup.log"

--- a/docker/travis/migrate.sh
+++ b/docker/travis/migrate.sh
@@ -5,6 +5,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 source $DIR/exchange-settings.sh;
 source $DIR/venv.sh
+source /etc/profile.d/vendor-libs.sh
 
 $CMD makemigrations
 $CMD collectstatic --noinput

--- a/docker/travis/run-server.sh
+++ b/docker/travis/run-server.sh
@@ -2,5 +2,6 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 source $DIR/exchange-settings.sh;
+source /etc/profile.d/vendor-libs.sh
 
 /env/bin/python /opt/boundless/exchange/manage.py runserver 0.0.0.0:8000

--- a/docker/travis/test-geonode.sh
+++ b/docker/travis/test-geonode.sh
@@ -3,6 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/exchange-settings.sh
 source $DIR/venv.sh
+source /etc/profile.d/vendor-libs.sh
 
 $CMD test geonode.tests.smoke --noinput --nocapture --detailed-errors --verbosity=1 --failfast
 #$CMD test geonode.people.tests geonode.base.tests geonode.layers.tests geonode.maps.tests geonode.proxy.tests geonode.security.tests geonode.social.tests geonode.catalogue.tests geonode.documents.tests geonode.api.tests geonode.groups.tests geonode.services.tests geonode.geoserver.tests geonode.upload.tests geonode.tasks.tests --noinput --failfast


### PR DESCRIPTION
The boundless-vendor-libs has been added to docker and vagrant configuration. The location of the libs are now in `/opt/boundless/vendor/lib`, the files have also been adjusted to add postgresql installed at `/opt/boundless/vendor/{lib,bin}`. The inclusion of the vendor-libs allowed for epel to be removed as a dependency. A settings variable, `GEOS_LIBRARY_PATH`, was added for docker config, since a custom location was used for geos.  

There was a change from having the Dockerfile for exchange install all requirements and then have common.sh upgrade the dependencies by using the upstream requirements. A change recently to upstream was causing issues when installing the dependency for six and paver. The change that has been applied to docker setup is to remove the geonode entry in the exchange requirements.txt and then install the local repo at `/mnt/geonode` in common.sh. This also aligns the python package versions that are installed in our rpm and in the vagrant dev setup.