### PR TITLE
Fly-by 'Error' Messages in resource lists.

### DIFF
--- a/exchange/templates/base/_resourcebase_snippet.html
+++ b/exchange/templates/base/_resourcebase_snippet.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% verbatim %}
 <div class="row">
-  <div ng-if="results.length == 0">
+  <div class="ng-hide" ng-show="results.length == 0">
     <div><h3>No {{ dataValue || 'content' }} created yet.</h3></div>
   </div>
   <article ng-repeat="item in results" resource_id="{{ item.id }}" ng-cloak class="ng-cloak">


### PR DESCRIPTION
The primary cause of this bug was that the message was showing
before Angular had the chance to parse the document.

Adding "ng-hide" to the div's class makes it invisible to the user
while the page was loading, and then "ng-show" is used to remove
the "ng-hide" class when applicable. But as that is done by the
Angular parser, the content is ready when the div is shown.

Refers to NODE-583