### PR TITLE
Revert waitress to previous version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ dj-database-url==0.4.2
 celery==3.1.18
 django-storages==1.1.8
 boto==2.38.0
-waitress==1.0.1
+waitress==0.9.0
 whitenoise==3.2
 django-cors-headers==1.1.0
 django-classification-banner==0.1.5


### PR DESCRIPTION
After version 0.9.0 waitress began stripping HTTP headers that contain
an '_' character. This is due to a potential security vulnerablity that
can arise from underscore/dash conflation.

GVS currently uses "OAM_REMOTE_USER" as a header in order to provide
authentication credentials to other services from their GeoAxis server.
This means that waitress needs to allow for that value until we determine
a better way forward with GVS.

This fix is meant to be a TEMPORARY solution so that GVS's testing team
can begin looking over their Exchgange deploy.

See https://github.com/Pylons/waitress/pull/80 and
https://www.djangoproject.com/weblog/2015/jan/13/security/ for more info
about the waitress security issue.