### PR TITLE
NODE-700 Manage and Edit style options are missing from Edit Data

### DIFF
--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -348,14 +348,14 @@
               {% endif %}
               {% if GEOSERVER_BASE_URL and not resource.service %}
                 {% if "change_layer_style" in layer_perms %}
-                <div class="col-sm-3">
-                  <i class="fa fa-tint fa-3x"></i>
-                  <h4>{% trans "Styles" %}</h4>
-                  {% if preview == 'geoext' %}
-                  <a class="btn btn-default btn-block btn-xs style-edit" data-dismiss="modal" href="#">{% trans "Edit" %}</a>
-                  <a class="btn btn-default btn-block btn-xs" href="{% url "layer_style_manage" resource.service_typename %}">{% trans "Manage" %}</a>
-                  {% endif %}
-                </div>
+                  <div class="col-sm-3">
+                    <i class="fa fa-tint fa-3x"></i>
+                    <h4>{% trans "Styles" %}</h4>
+                    {% if preview == 'geoext' %}
+                      <a class="btn btn-default btn-block btn-xs style-edit" data-dismiss="modal" href="#">{% trans "Edit" %}</a>
+                    {% endif %}
+                    <a class="btn btn-default btn-block btn-xs" href="{% url "layer_style_manage" resource.service_typename %}">{% trans "Manage" %}</a>
+                  </div> 
                 {% endif %}
               {% endif %}
               {% if "change_resourcebase" in perms_list %}


### PR DESCRIPTION
The buttons are hidden when the preview viewer is react, the buttons were set to geoxt viewer only (geoext viewer is the old ol2 viewer).  An issue has been created in geonode-client [https://github.com/GeoNode/geonode-client/issues/145]. Modified the template to at least expose the option to manage the available styles, until the feature can be added to the ol3 react viewer.