### PR TITLE
NODE-703 Add celery[redis] bundle for redis broker support for celery.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ git+git://github.com/boundlessgeo/django-exchange-maploom.git@v1.5.14#django-exc
 git+git://github.com/GeoNode/geonode@85f7aad07255a03845616bfb6d7696e71edba0d0#egg=geonode
 django-geonode-client==0.0.15
 dj-database-url==0.4.2
-celery==3.1.18
+celery[redis]==3.1.18
 django-storages==1.1.8
 boto==2.38.0
 waitress==0.9.0


### PR DESCRIPTION
http://docs.celeryproject.org/en/3.1/configuration.html#redis-backend-settings

#144


