### PR TITLE
fix to category filters

### DIFF
--- a/exchange/views.py
+++ b/exchange/views.py
@@ -209,6 +209,9 @@ def unified_elastic_search(request):
     categories = parameters.getlist('category__in',
                                     parameters.getlist('category__identifier__in', None))
 
+    keywords = parameters.getlist('keywords__in',
+                                  parameters.getlist('keywords__slug__in', None))
+
     # Publication date range (start,end)
     date_end = parameters.get("date__lte", None)
     date_start = parameters.get("date__gte", None)
@@ -292,21 +295,28 @@ def unified_elastic_search(request):
         q = Q({'terms': {'category_exact': categories}})
         search = search.query(q)
 
+    if keywords:
+        q = Q({'terms': {'keywords_exact': keywords}})
+        search = search.query(q)
+
     def facet_search(search, parameters, paramfield, esfield=None):
         if esfield is None:
             esfield = paramfield.replace('__in', '')
+        if esfield != '_index':
+            esfield = esfield + '_exact'
         getparams = parameters.getlist(paramfield)
         if getparams:
             q = Q({'terms': {esfield: getparams}})
-            if esfield == 'type':
-                q = q | Q({'terms': {'subtype': getparams}})
+            if esfield == 'type_exact':
+                q = q | Q({'terms': {'subtype_exact': getparams}})
             return search.query(q)
         return search
 
     # Setup aggregations and filters for faceting
     for f in facets:
         param = '%s__in' % f
-        search = facet_search(search, parameters, param)
+        if f not in ['category', 'keywords']:
+            search = facet_search(search, parameters, param)
         search.aggs.bucket(f, 'terms', field=f + '_exact')
 
     # Apply sort

--- a/exchange/views.py
+++ b/exchange/views.py
@@ -289,10 +289,7 @@ def unified_elastic_search(request):
         search = search.query(q)
 
     if categories:
-        q = Q({'terms': {'category': categories}})
-        #also check for truncated categories
-        trunc_cats = [c[:13] for c in categories]
-        q = q | Q({'terms': {'category': trunc_cats}})
+        q = Q({'terms': {'category_exact': categories}})
         search = search.query(q)
 
     def facet_search(search, parameters, paramfield, esfield=None):
@@ -310,7 +307,7 @@ def unified_elastic_search(request):
     for f in facets:
         param = '%s__in' % f
         search = facet_search(search, parameters, param)
-        search.aggs.bucket(f, 'terms', field=f)
+        search.aggs.bucket(f, 'terms', field=f + '_exact')
 
     # Apply sort
     if sort.lower() == "-date":


### PR DESCRIPTION
Fixes issue with category filters in unified search. For some reason Elastic Search is truncating categories to 13 characters, so this truncates the query to match. Should still figure out what is causing this.