### PR TITLE
Fixed missing createMapThumbnail function

### DIFF
--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -25,7 +25,8 @@
   {% elif preview == 'OL3' %}
     {% include "layers/layer_ol3_map.html" %}
   {% elif preview == 'react' %}
-		{% include 'geonode-client/layer_map.html' %}
+    <script type="text/javascript" src="{{ STATIC_URL}}geonode/js/utils/thumbnail.js"></script>
+    {% include 'geonode-client/layer_map.html' %}
   {% else %}
     {% include "layers/layer_leaflet_map.html" %}
   {% endif %}


### PR DESCRIPTION
The createMapThumbnail function is in thumbnail.js which
    was not being included by the geonode-client app.  The exchange
    template has been changed to include the necesary javascript file
    before loading the Geonode-client package map.