### PR TITLE
Allow for passing a preview configuration.

### DIFF
--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -31,6 +31,7 @@ def resource_variables(request):
         MAP_CRS=getattr(settings, 'DEFAULT_MAP_CRS', None),
         INSTALLED_APPS=set(settings.INSTALLED_APPS),
         GEOAXIS_ENABLED=getattr(settings, 'GEOAXIS_ENABLED', False),
+        MAP_PREVIEW_LAYER=getattr(settings, 'MAP_PREVIEW_LAYER', "''"),
     )
 
     return defaults


### PR DESCRIPTION
Adds support for a 'preview layer' configuration that is
passed onto maploom.

Setting MAP_PREVIEW_LAYER will be pushed to the templates so that it can be rendered in the map:
```
MAP_PREVIEW_LAYER = {
  "source": {"ptype": "gxp_arcrestsource",
             "url": "https://services.arcgisonline.com/arcgis/rest/services/ESRI_Imagery_World_2D/MapServer/",
             "proj": "EPSG:4326"},
  "args": ["Worldmap",
            "https://services.arcgisonline.com/arcgis/rest/services/ESRI_Imagery_World_2D/MapServer/",
           {"layers": "basic"}],

}
```

