### PR TITLE
Fixed incorrect empty search text messages for maps/layers

### DIFF
--- a/exchange/templates/base/_resourcebase_snippet.html
+++ b/exchange/templates/base/_resourcebase_snippet.html
@@ -3,7 +3,7 @@
 <script src="/static/js/clipboard.min.js"></script>
 <div class="row">
   <div class="ng-hide" ng-show="results.length == 0">
-    <div><h3>No {{ dataValue || 'content' }} created yet.</h3></div>
+    <div><h3>No content created yet.</h3></div>
   </div>
   <article ng-repeat="item in results" resource_id="{{ item.id || item.layer_identifier }}" ng-cloak class="ng-cloak">
     <div class="col-xs-12 item-container" ng-if="item.detail_url">


### PR DESCRIPTION
This is a little ugly but because this template is reused in multiple places and the dataValue variable is reused in those places to mean completely different things, it's placing an ad hoc if check to see if we should use dataValue as part of the message to display or not.

Alternatively, can just use the word "content" or something to have a generic static message instead.