### PR TITLE
adjusting settings check for WGS84

### DIFF
--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -232,8 +232,8 @@ DATABASES['exchange_imports'] = dj_database_url.parse(
     conn_max_age=600
 )
 
-WGS84_MAP_CRS = os.environ.get('WGS84_MAP_CRS', None)
-if WGS84_MAP_CRS is not None:
+WGS84_MAP_CRS = str2bool(os.environ.get('WGS84_MAP_CRS', False))
+if WGS84_MAP_CRS:
     DEFAULT_MAP_CRS = "EPSG:4326"
 
 # local pycsw


### PR DESCRIPTION
The previous check was checking if the value was not null, which caused an issue when the exchange-settings.sh was set to False.