### PR TITLE
geonode.rest -> geonode.importer for Geogig imports

### DIFF
--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -136,11 +136,10 @@ if OSGEO_IMPORTER_ENABLED:
     INSTALLED_APPS = ('osgeo_importer',) + INSTALLED_APPS
 else:
     UPLOADER = {
-        'BACKEND': 'geonode.rest',
+        'BACKEND': 'geonode.importer',
         'OPTIONS': {
             'TIME_ENABLED': True,
             'MOSAIC_ENABLED': False,
-            'GEOGIG_ENABLED': True,
         }
     }
 


### PR DESCRIPTION
Using ```geonode.importer``` instead of ```geonode.rest``` to support importing into Geogig