### PR TITLE
make documents and layers search use unified search when enabled

### DIFF
--- a/exchange/urls.py
+++ b/exchange/urls.py
@@ -70,7 +70,19 @@ if 'osgeo_importer' in settings.INSTALLED_APPS:
 
 # use combined registry/geonode elastic search rather than geonode search
 if settings.ES_UNIFIED_SEARCH:
-    urlpatterns += [url(r'^api/base/search/$',
+    urlpatterns += [url(r'^api/(?P<resourcetype>base)/search/$',
+                        views.unified_elastic_search,
+                        name='unified_elastic_search')]
+    urlpatterns += [url(r'^api/(?P<resourcetype>documents)/search/$',
+                        views.unified_elastic_search,
+                        name='unified_elastic_search')]
+    urlpatterns += [url(r'^api/(?P<resourcetype>layers)/search/$',
+                        views.unified_elastic_search,
+                        name='unified_elastic_search')]
+    urlpatterns += [url(r'^api/(?P<resourcetype>maps)/search/$',
+                        views.unified_elastic_search,
+                        name='unified_elastic_search')]
+    urlpatterns += [url(r'^api/(?P<resourcetype>registry)/search/$',
                         views.unified_elastic_search,
                         name='unified_elastic_search')]
 

--- a/exchange/views.py
+++ b/exchange/views.py
@@ -169,7 +169,7 @@ def csw_status_table(request):
                               context_instance=RequestContext(request))
 
 
-def unified_elastic_search(request):
+def unified_elastic_search(request, resourcetype='base'):
     import re
     import requests
     from elasticsearch import Elasticsearch
@@ -221,6 +221,18 @@ def unified_elastic_search(request):
 
     # Geospatial Elements
     bbox = parameters.get("extent", None)
+
+    # filter by resource type if included by path
+    logger.debug('-------------------------------------------------------------')
+    logger.debug('>>>>>>>>> Filtering by Resource Type %s <<<<<<<<<<<<<' % resourcetype)
+    logger.debug('-------------------------------------------------------------')
+
+    if resourcetype == 'documents':
+        search = search.query("match", type_exact="document")
+    elif resourcetype == 'layers':
+        search = search.query("match", type_exact="layer")
+    elif resourcetype == 'maps':
+        search = search.query("match", type_exact="map")
 
     # Filter geonode layers by permissions
     if not settings.SKIP_PERMS_FILTER:


### PR DESCRIPTION
it seems as though bumping ES versions was creating issues with haystack search on dev.exchange. this makes all searches run through the ES_UNIFIED SEARCH when enabled

addresses NODE-752