### PR TITLE
Added Support for Local Registry Development.

### DIFF
--- a/docker-compose-unified-search.yml
+++ b/docker-compose-unified-search.yml
@@ -15,6 +15,12 @@ services:
             - "8001"
         volumes:
             - scratch:/scratch
+
+            # For local dev'ing, uncomment the below
+            #  If using the line below verbatim, 
+            #  registry must be cloned to ~/boundless/registry
+            # - ~/boundless/registry:/opt/registry:ro
+
         networks:
             internal:
             # Expose on a fixed host IP for diagnostic purposes.

--- a/docker/registry/Dockerfile
+++ b/docker/registry/Dockerfile
@@ -1,12 +1,34 @@
 FROM centos:6.7
 
-RUN yum -y install https://s3.amazonaws.com/exchange-development-yum/exchange-development-repo-1.0.0.noarch.rpm  && \
-    yum update -y && \
-    yum --nogpgcheck -y install registry
+RUN yum install -y https://s3.amazonaws.com/exchange-development-yum/exchange-development-repo-1.0.0.noarch.rpm
+RUN yum update -y
+
+RUN yum -y install boundless-vendor-libs \
+                   libtiff-devel \
+                   libxml2-devel \
+                   libxslt-devel \
+                   make \
+                   gcc \
+                   gcc-c++
+
+RUN yum install -y python27 python27-devel python27-setuptools python27-virtualenv git
+RUN /usr/local/bin/virtualenv /env && chmod -R 755 /env
 
 EXPOSE 8001
 
-RUN /usr/bin/registry-createdb
+RUN git clone https://github.com/boundlessgeo/registry/ /opt/registry/
 
-WORKDIR /scratch
-CMD  /opt/registry/registry.sh
+ADD registry-settings.sh /etc/profile.d/
+
+
+ADD setupdb.sh /root/
+ADD run.sh /root/
+
+# globally install what registry needs.
+WORKDIR /opt/registry/
+RUN source /env/bin/activate && pip install -r requirements.txt
+
+# inititalize
+RUN /root/setupdb.sh
+
+CMD /root/run.sh

--- a/docker/registry/registry-settings.sh
+++ b/docker/registry/registry-settings.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+export REGISTRY_DEBUG=${REGISTRY_DEBUG:-'True'}
+export REGISTRY_SECRET_KEY=${REGISTRY_SECRET_KEY:-'Make sure you create a good secret key.'}
+export REGISTRY_MAPPING_PRECISION=${REGISTRY_MAPPING_PRECISION:-'500m'}
+export REGISTRY_SEARCH_URL=${REGISTRY_SEARCH_URL:-'http://127.0.0.1:9200'}
+export REGISTRY_DATABASE_URL=${REGISTRY_DATABASE_URL:-'sqlite:////tmp/registry.db'}
+export MAPPROXY_CACHE_DIR=${MAPPROXY_CACHE_DIR:-'/tmp'}
+export REGISTRY_ALLOWED_IPS=${REGISTRY_ALLOWED_IPS:-'*'}
+
+set +e

--- a/docker/registry/run.sh
+++ b/docker/registry/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source /etc/profile.d/registry-settings.sh
+source /etc/profile.d/vendor-libs.sh
+source /env/bin/activate
+
+cd /opt/registry
+
+python registry.py runserver 0.0.0.0:8001

--- a/docker/registry/setupdb.sh
+++ b/docker/registry/setupdb.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source /etc/profile.d/registry-settings.sh
+source /etc/profile.d/vendor-libs.sh
+source /env/bin/activate
+
+cd /opt/registry
+
+python registry.py pycsw -c setup_db


### PR DESCRIPTION
The previous version of the registry docker setup
used the registry RPM to setup the registry environment. This version
of the docker file properly sets up the environment to use a clone
of the repository.  If the developer wishes then they can setup
a "local mount" of the repository and develop in a similar manner
to how exchange, maploom, and geonode are currently configured.