### PR TITLE
Social login V2

### DIFF
--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -137,7 +137,6 @@ INSTALLED_APPS = (
     'maploom',
     'solo',
     'exchange-docs',
-    'social.apps.django_app.default',
 ) + ADDITIONAL_APPS + INSTALLED_APPS
 
 if OSGEO_IMPORTER_ENABLED:
@@ -414,26 +413,27 @@ DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION = True
 ENABLE_SOCIAL_LOGIN = str2bool(os.getenv('ENABLE_SOCIAL_LOGIN', 'False'))
 
 if ENABLE_SOCIAL_LOGIN:
+    INSTALLED_APPS = ('social_django',) + INSTALLED_APPS
     SOCIAL_AUTH_NEW_USER_REDIRECT_URL = '/'
 
     AUTHENTICATION_BACKENDS += (
-        'social.backends.google.GoogleOAuth2',
-        'social.backends.facebook.FacebookOAuth2',
-        'exchange.auth.backends.geoaxis.GeoAxisOAuth2',
+        'social_core.backends.google.GoogleOpenId',
+        'social_core.backends.google.GoogleOAuth2',
+        'social_core.backends.facebook.FacebookOAuth2',
     )
 
     DEFAULT_AUTH_PIPELINE = (
-        'social.pipeline.social_auth.social_details',
-        'social.pipeline.social_auth.social_uid',
-        'social.pipeline.social_auth.auth_allowed',
-        'social.pipeline.social_auth.social_user',
-        'social.pipeline.user.get_username',
-        'social.pipeline.mail.mail_validation',
-        'social.pipeline.social_auth.associate_by_email',
-        'social.pipeline.user.create_user',
-        'social.pipeline.social_auth.associate_user',
-        'social.pipeline.social_auth.load_extra_data',
-        'social.pipeline.user.user_details'
+        'social_core.pipeline.social_auth.social_details',
+        'social_core.pipeline.social_auth.social_uid',
+        'social_core.pipeline.social_auth.auth_allowed',
+        'social_core.pipeline.social_auth.social_user',
+        'social_core.pipeline.user.get_username',
+        'social_core.pipeline.mail.mail_validation',
+        'social_core.pipeline.social_auth.associate_by_email',
+        'social_core.pipeline.user.create_user',
+        'social_core.pipeline.social_auth.associate_user',
+        'social_core.pipeline.social_auth.load_extra_data',
+        'social_core.pipeline.user.user_details'
     )
 
     SOCIAL_AUTH_FACEBOOK_KEY = os.environ.get('OAUTH_FACEBOOK_KEY', None)
@@ -454,3 +454,8 @@ if ENABLE_SOCIAL_LOGIN:
     SOCIAL_AUTH_GEOAXIS_SECRET = os.environ.get('OAUTH_GEOAXIS_SECRET', None)
     SOCIAL_AUTH_GEOAXIS_HOST = os.environ.get('OAUTH_GEOAXIS_HOST', None)
     ENABLE_GEOAXIS_LOGIN = isValid(SOCIAL_AUTH_GEOAXIS_KEY)
+    # GeoAxisOAuth2 will cause all login attempt to fail if SOCIAL_AUTH_GEOAXIS_HOST is None
+    if ENABLE_GEOAXIS_LOGIN:
+        AUTHENTICATION_BACKENDS += (
+            'exchange.auth.backends.geoaxis.GeoAxisOAuth2',
+        )

--- a/exchange/themes/templates/base.html
+++ b/exchange/themes/templates/base.html
@@ -168,12 +168,12 @@
       <footer class="footer">
         <div class="container">
           <div class="row">
-            <div class="col-md-8 small-text">
+            <div class="text-center stacked">
               <span>{% trans "Powered by" %}&nbsp;&nbsp;
                 {% if theme.pb_link %}
                   <a href="{{ theme.pb_link }}" target="_new">
                 {% else %}
-                  <a href="http://boundlessgeo.com/" target="_new">
+                  <a href="https://boundlessgeo.com/" target="_new">
                 {% endif %}
                 {% if theme.pb_text %}
                   {{ theme.pb_text }}</a>

--- a/exchange/urls.py
+++ b/exchange/urls.py
@@ -55,7 +55,7 @@ if settings.REGISTRY is False:
 
 if settings.ENABLE_SOCIAL_LOGIN is True:
     urlpatterns += [
-        url('', include('social.apps.django_app.urls', namespace='social'))
+        url('', include('social_django.urls', namespace='social'))
     ]
 
 # If django-osgeo-importer is enabled...

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ django-flat-theme==1.1.3
 django-exchange-docs==1.1.3
 flake8==3.0.4
 elasticsearch-dsl==5.0.0
-python-social-auth==0.2.21
+social-auth-app-django==1.1.0


### PR DESCRIPTION
This replaces the deprecated ```python-social-auth``` to ```social-auth-app-django```.
Also moved the ```social_django``` app to only be included if social login is enabled

This was tested on https://dev.exchange.boundlessps.com

**Known issues:**
- On initial login from Google the user will be pointed to ```/accounts/profile/```
- Authentication to Goggle backend will fail because  ```certifi``` (even the latest version) has an old cacerts.
```certifi```will have to be uninstalled
