### PR TITLE
codecov.io integration

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: Dh8xvjb3IUvWDNEbPdyKQF2A2KB6DG3kC

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,6 @@ script:
   # run exchange tests and coverage
   - docker exec ci-exchange /opt/boundless/exchange/docker/travis/pytests.sh
 
-
-after_success:
-  - docker exec ci-exchange /opt/boundless/exchange/docker/travis/coveralls.sh
-
 after_failure:
   - docker logs ci-exchange
 

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 geonode-exchange
 ================
 
-.. image:: https://coveralls.io/repos/github/boundlessgeo/exchange/badge.svg?branch=master
-    :target: https://coveralls.io/github/boundlessgeo/exchange?branch=master
+.. image:: https://codecov.io/gh/boundlessgeo/exchange/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/boundlessgeo/exchange
 
 .. image:: https://travis-ci.org/boundlessgeo/exchange.svg?branch=master
     :target: https://travis-ci.org/boundlessgeo/exchange

--- a/docker/travis/Dockerfile.ci
+++ b/docker/travis/Dockerfile.ci
@@ -13,7 +13,7 @@ RUN echo "GEOS_LIBRARY_PATH = '/opt/boundless/vendor/lib/libgeos_c.so'" >> /opt/
 # install python dependencies
 RUN virtualenv /env && chmod -R 755 /env
 RUN PATH=$PATH:/opt/boundless/vendor/bin && /env/bin/pip install -r /opt/boundless/exchange/requirements.txt
-RUN /env/bin/pip install pytest coverage pytest-cov coveralls
+RUN /env/bin/pip install pytest coverage pytest-cov
 
 # setup django
 RUN /opt/boundless/exchange/docker/travis/setup.sh

--- a/docker/travis/coveralls.sh
+++ b/docker/travis/coveralls.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $DIR/common.sh
-cd /opt/boundless/exchange
-
-# run coverage
-/env/bin/coveralls debug

--- a/docker/travis/pytests.sh
+++ b/docker/travis/pytests.sh
@@ -14,3 +14,4 @@ cd /opt/boundless/exchange
 
 # run tests
 PYTEST=True bash -c '/env/bin/py.test --cov exchange exchange/tests/'
+bash <(curl -s https://codecov.io/bash) -cF python -t ad26f590-7fc2-4f1a-b3a4-c98b1e9cd039


### PR DESCRIPTION
adjusted coverage reporting to use codecov.io not coveralls.io, codecov has a bash command that allows publishing the report within the container. Updated the badge in the readme.