### PR TITLE
Allow setting of GEOAXIS_HEADER via ENV VARS

### DIFF
--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -346,6 +346,7 @@ if all([AUTH_LDAP_SERVER_URI, LDAP_SEARCH_DN]):
 # geoaxis
 GEOAXIS_ENABLED = str2bool(os.getenv('GEOAXIS_ENABLED', 'False'))
 if GEOAXIS_ENABLED:
+    GEOAXIS_HEADER = os.getenv('GEOAXIS_HEADER', None)
     AUTHENTICATION_BACKENDS = (
         'django.contrib.auth.backends.RemoteUserBackend',
     ) + AUTHENTICATION_BACKENDS


### PR DESCRIPTION
The value that Geoaxis returns as its header for
authentication is customizable and can vary from
instance to instance. As a result the user of
Exchange should be able to customize the value
Exchange looks for to match their flavor of
Geoaxis.