### PR TITLE
"Workspace" addition bugs

### DIFF
--- a/exchange/static/css/site_base.css
+++ b/exchange/static/css/site_base.css
@@ -143,3 +143,21 @@ input[value='Invite User'] {
 span[id^="error_"].help-inline {
   color: #d9534f;
 }
+
+resource-cart span.cart-label {
+    display: inline-block;
+    overflow: hidden;
+}
+
+
+@media screen and (min-width: 960px) {
+    resource-cart span.cart-label {
+        max-width: 150px;
+    }
+}
+
+@media screen and (min-width: 1200px) { 
+    resource-cart span.cart-label {
+        max-width: 200px;
+    }
+}

--- a/exchange/static/js/search/workspace.html
+++ b/exchange/static/js/search/workspace.html
@@ -4,6 +4,9 @@
     <p ng-show="!cart.getCart().items.length">Add resources through the "Add to workspace" buttons.</p>
   </div>
   <ul class="list-group">
-    <li class="list-group-item" ng-repeat="resource in cart.getCart().items">{{ resource.title | limitTo: 25}}{{ resource.title.length > 25 ? '...' : '' }}<button class="btn btn-default btn-xs pull-right" ng-click="cart.removeItem(resource)"><i class="fa fa-remove fa-lg"></i></button></li>
+    <li class="list-group-item" ng-repeat="resource in cart.getCart().items">
+        <span class="cart-label">{{ resource.title | limitTo: 25}}{{ resource.title.length > 25 ? '...' : '' }}</span>
+        <button class="btn btn-default btn-xs pull-right" ng-click="cart.removeItem(resource)"><i class="fa fa-remove fa-lg"></i></button>
+    </li>
   </ul>
 </div>

--- a/exchange/templates/base/_resourcebase_snippet.html
+++ b/exchange/templates/base/_resourcebase_snippet.html
@@ -13,7 +13,7 @@
         </div>
         <div class="col-xs-8 item-details">
           {% endverbatim %}
-          <button class="btn btn-default btn-xs pull-right" ng-if="cart" ng-click="cart.toggleItem(item)"><i ng-class="cart.getFaClass(item.id)" class="fa fa-lg"></i></button>
+          <button ng-if="cart && item.detail_url.indexOf('/layers/') > -1" class="btn btn-default btn-xs pull-right" ng-click="cart.toggleItem(item)"><i ng-class="cart.getFaClass(item.id)" class="fa fa-lg"></i></button>
           {% verbatim %}
           <p class="item-meta"><span class="item-category">{{ item.category__gn_description }}</span></p>
           <h4><a href="{{ item.detail_url }}">{{ item.title }}</a></h4>
@@ -46,7 +46,6 @@
         </div>
         <div class="col-xs-8 item-details">
           {% endverbatim %}
-          <button class="btn btn-default btn-xs pull-right" ng-if="cart" ng-click="cart.toggleItem(item)"><i ng-class="cart.getFaClass(item.layer_identifier)" class="fa fa-lg"></i></button>
           {% verbatim %}
           <p class="item-meta"><span class="item-category">{{ item.registry.category }}</span></p>
           <h4>{{ item.title }}</h4>

--- a/exchange/templates/search/search.html
+++ b/exchange/templates/search/search.html
@@ -12,7 +12,7 @@
     <h2>{% trans "Search" %} <span ng-if="text_query != ''">:</span> <span ng-bind="text_query"></span></h2>
   </div>
   {% with include_type_filter='true' %}
-  {% with facet_type='layers' %}
+  {% with include_create_map='true' %}
   {% with header='Type' %}
   {% with filter='type__in' %}
   {% include "search/_search_content.html" %}

--- a/exchange/templates/search/search.html
+++ b/exchange/templates/search/search.html
@@ -1,0 +1,39 @@
+{% extends "site_base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% load url from future %}
+
+{% block title %} {% trans "Search" %} - {{ block.super }} {% endblock %}
+
+{% block body_class %}search{% endblock %}
+
+{% block body_outer %}
+  <div class="page-header">
+    <h2>{% trans "Search" %} <span ng-if="text_query != ''">:</span> <span ng-bind="text_query"></span></h2>
+  </div>
+  {% with include_type_filter='true' %}
+  {% with facet_type='layers' %}
+  {% with header='Type' %}
+  {% with filter='type__in' %}
+  {% include "search/_search_content.html" %}
+  {% endwith %}
+  {% endwith %}
+  {% endwith %}
+  {% endwith %}
+{% endblock %}
+
+{% block extra_script %}
+  {% if GEONODE_SECURITY_ENABLED %}
+    {% include "_permissions_form_js.html" %}
+  {% endif %}
+  <script type="text/javascript">
+    {% if HAYSTACK_SEARCH %}
+    SEARCH_URL = '{% url 'api_get_search' api_name='api' resource_name='base' %}'
+    {% else %}
+    SEARCH_URL = '{% url 'api_dispatch_list' api_name='api' resource_name='base' %}'
+    {% endif %}
+  </script>
+  {% with include_spatial='true' %}
+  {% include 'search/search_scripts.html' %}
+  {% endwith %}
+{% endblock extra_script %}


### PR DESCRIPTION
In the new search screen it was possible to add registry layers and maps to the "Workspace"/cart.  These things are broken functionality in the current application.  This PR prevents the user from performing those actions. A bit of detail:

1. Fixes from CSS with the cart items when the title gets too long.
2. Filter out "add" buttons from items which are not layers.
3. Ensure all filters and the "Create a Map" button can be displayed at the same time.

Depends on : 
- https://github.com/boundlessgeo/geonode/pull/39

Screenshot:
![image](https://cloud.githubusercontent.com/assets/1282291/23958159/2c163dce-096f-11e7-8ff8-26ee0717965e.png)
