### PR TITLE
Added additional CSS to prevent fly-by message.

### DIFF
--- a/exchange/themes/templates/index.html
+++ b/exchange/themes/templates/index.html
@@ -80,7 +80,7 @@
   	</div>
   </section>
 
-  <section id="showcase">
+  <section id="showcase" style="display:none">
     <div class="container">
       <div class="row">
         <h2>Featured Datasets</h2>
@@ -116,6 +116,7 @@
       module.run(function($http, $rootScope){
         $http.get(FEATURED_URL).success(function(data){
           $rootScope.featured = data.objects;
+          document.getElementById('showcase').style.display = 'block';
         });
       });
     })();


### PR DESCRIPTION
Inline CSS does not need to wait for CSS or Angular to load to
hide the contents of the feature datasets.  Only once the layer
list has loaded will the list display.