### PR TITLE
Testing/cleanup test structure

### DIFF
--- a/exchange/settings/test_settings.py
+++ b/exchange/settings/test_settings.py
@@ -26,16 +26,6 @@ _INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
 )
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
-)
 #TEMPLATES = [
 #    {
 #        'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/exchange/tests/fileservice_test.py
+++ b/exchange/tests/fileservice_test.py
@@ -7,7 +7,9 @@ from django.http import HttpResponse
 from mock import mock_open
 import mock
 
-class FileItemResourceTest(ResourceTestCaseMixin, TestCase):
+from . import ExchangeTest
+
+class FileItemResourceTest(ResourceTestCaseMixin, ExchangeTest):
 
     def setUp(self):
         super(FileItemResourceTest, self).setUp()

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ django-exchange-docs==1.1.3
 flake8==3.0.4
 elasticsearch-dsl==5.0.0
 social-auth-app-django==1.1.0
+mock==2.0.0


### PR DESCRIPTION
Refactored views and fileservice tests for consistency.
    
1. Added "mock" module  that was missing and required
       by the fileservice_test.py
    
2. Migrated all tests in views_test to use ExchangeTest mixin.
    
3. Migrated fileservice_test stests to use ExchangeTest mixin.

4. There were rendering errors for the uploader tests using
    the custom middleware settings.  This keeps the middleware
    settings closer to that of the real environment.
