### PR TITLE
Apply Styling to the Social Buttons

### DIFF
--- a/exchange/templates/account/login.html
+++ b/exchange/templates/account/login.html
@@ -29,7 +29,7 @@
     <div class="row">
         {% if ENABLE_FACEBOOK_LOGIN %}
     	<div class="col-sm-4">
-            <a href="{% url 'social:begin' 'facebook' %}">
+            <a href="{% url 'social:begin' 'facebook' %}?next={{ request.path }}">
                 <div class="facebook-btn btn btn-md bg-ms btn-block">
                     <i class="fa fa-facebook"></i> Log In with Facebook
                 </div>
@@ -38,7 +38,7 @@
         {% endif %}
         {% if ENABLE_GOOGLE_LOGIN %}
         <div class="col-sm-4">
-            <a href="{% url 'social:begin' 'google-oauth2' %}">
+            <a href="{% url 'social:begin' 'google-oauth2' %}?next={{ request.path }}">
                 <div class="google-btn btn btn-md bg-ms btn-block">
                     <i class="fa fa-google"></i> Log In with Google
                 </div>
@@ -47,7 +47,7 @@
         {% endif %}
         {% if ENABLE_GEOAXIS_LOGIN %}
          <div class="col-sm-4">
-            <a href="{% url 'social:begin' 'geoaxis' %}">
+            <a href="{% url 'social:begin' 'geoaxis' %}?next={{ request.path }}">
                 <div class="google-btn btn btn-md bg-ms btn-block">
                     Log In with GeoAxis
                 </div>

--- a/exchange/templates/account/login.html
+++ b/exchange/templates/account/login.html
@@ -8,7 +8,7 @@
 
 {% block body_outer %}
 <div class="page-header">
-  <h2>{% trans "Log in to an existing account" %}</h2>
+  <h2>{% trans "Log In to an existing account" %}</h2>
 </div>
 <div class="row">
   <div class="col-md-8">
@@ -22,37 +22,29 @@
         <p><a href="{% url "forgot_username" %}">{% trans "Forgot your username?" %}</a></p>
         <p><a href="{% url "account_password_reset" %}">{% trans "Forgot your password?" %}</a></p>
       </div>
-      <button type="submit" class="btn btn-primary">{% trans "Log in" %}</button>
+      <button type="submit" class="btn btn-primary">{% trans "Log In" %}</button>
     </form>
+
   </div>
+
    {% if ENABLE_SOCIAL_LOGIN %}
-    <div class="row">
+
+    <div class="col-md-4" style="float:right;">
+
         {% if ENABLE_FACEBOOK_LOGIN %}
-    	<div class="col-sm-4">
-            <a href="{% url 'social:begin' 'facebook' %}?next={{ request.path }}">
-                <div class="facebook-btn btn btn-md bg-ms btn-block">
-                    <i class="fa fa-facebook"></i> Log In with Facebook
-                </div>
+            <a class="btn-facebook btn-social btn bg-ms btn-block" href="{% url 'social:begin' 'facebook' %}?{{ redirect_field_name }}={{ redirect_field_value }}">
+                <i class="fa fa-facebook"></i> Log In with Facebook
             </a>
-        </div>
         {% endif %}
         {% if ENABLE_GOOGLE_LOGIN %}
-        <div class="col-sm-4">
-            <a href="{% url 'social:begin' 'google-oauth2' %}?next={{ request.path }}">
-                <div class="google-btn btn btn-md bg-ms btn-block">
-                    <i class="fa fa-google"></i> Log In with Google
-                </div>
+            <a class="btn-google btn-social btn bg-ms btn-block" href="{% url 'social:begin' 'google-oauth2' %}?{{ redirect_field_name }}={{ redirect_field_value }}">
+                <i class="fa fa-google"></i> Log In with Google
             </a>
-        </div>
         {% endif %}
         {% if ENABLE_GEOAXIS_LOGIN %}
-         <div class="col-sm-4">
-            <a href="{% url 'social:begin' 'geoaxis' %}?next={{ request.path }}">
-                <div class="google-btn btn btn-md bg-ms btn-block">
-                    Log In with GeoAxis
-                </div>
+            <a class="btn-geoaxis btn-social btn bg-ms btn-block" href="{% url 'social:begin' 'geoaxis' %}?{{ redirect_field_name }}={{ redirect_field_value }}">
+                <i class="fa fa-lock"></i> Log In with GeoAxis
             </a>
-        </div>
         {% endif %}
     </div>
     {% endif %}

--- a/exchange/themes/static/theme/css/site_base.css
+++ b/exchange/themes/static/theme/css/site_base.css
@@ -128,3 +128,71 @@ h1, h2, h3, h4, h5, h6 {
     outline-width: 0;
     font-size: 1.5em;
 }
+
+/* Social Login Buttons*/
+
+.btn-google {
+    color: #fff;
+    background-color: #dd4b39;
+    border-color: rgba(0,0,0,0.2);
+}
+
+.btn-google:hover{
+    color:#fff;
+    background-color:#c23321;
+    border-color:rgba(0,0,0,0.2);
+    text-decoration: none;
+}
+
+.btn-facebook {
+    color: #fff;
+    background-color: #3b5998;
+    border-color: rgba(0,0,0,0.2);
+}
+
+.btn-facebook:hover{
+    color:#fff;
+    background-color:#2d4373;
+    border-color:rgba(0,0,0,0.2);
+    text-decoration: none;
+}
+
+.btn-geoaxis {
+    color:#fff;
+    background-color: #16aa3e;
+    border-color:rgba(0,0,0,0.2);
+    text-decoration: none;
+}
+
+
+.btn-geoaxis:hover{
+    color:#fff;
+    background-color:#008000;
+    border-color:rgba(0,0,0,0.2);
+    text-decoration: none;
+}
+
+.btn-social {
+    position: relative;
+    padding-left: 44px;
+    text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 5px;
+    text-decoration: none;
+    font-weight: 300;
+    font-size: 15px;
+}
+
+.btn-social>:first-child {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 32px;
+    line-height: 34px;
+    font-size: 1.6em;
+    text-align: center;
+    border-right: 1px solid rgba(0,0,0,0.2);
+}


### PR DESCRIPTION
This PR fixes:

- the google redirect error by supplying the `next` parameter

- applies styling to the social buttons.
- consistent use of `Log In` instead of `Log in` or `Sign in`