### PR TITLE
Consent Banner for Exchange

### DIFF
--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -37,7 +37,7 @@ def resource_variables(request):
         GEOAXIS_ENABLED=getattr(settings, 'GEOAXIS_ENABLED', False),
         MAP_PREVIEW_LAYER=getattr(settings, 'MAP_PREVIEW_LAYER', "''"),
         LOCKDOWN_EXCHANGE=getattr(settings, 'LOCKDOWN_GEONODE', False),
-        LOGIN_WARNING=getattr(settings, 'LOGIN_WARNING', False),
+        LOGIN_WARNING=getattr(settings, 'LOGIN_WARNING_ENABLED', False),
         LOGIN_WARNING_TEXT=getattr(settings, 'LOGIN_WARNING_TEXT', "''")
     )
 

--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -36,6 +36,7 @@ def resource_variables(request):
         INSTALLED_APPS=set(settings.INSTALLED_APPS),
         GEOAXIS_ENABLED=getattr(settings, 'GEOAXIS_ENABLED', False),
         MAP_PREVIEW_LAYER=getattr(settings, 'MAP_PREVIEW_LAYER', "''"),
+        LOCKDOWN_EXCHANGE=getattr(settings, 'LOCKDOWN_GEONODE', False),
     )
 
     return defaults

--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -37,6 +37,8 @@ def resource_variables(request):
         GEOAXIS_ENABLED=getattr(settings, 'GEOAXIS_ENABLED', False),
         MAP_PREVIEW_LAYER=getattr(settings, 'MAP_PREVIEW_LAYER', "''"),
         LOCKDOWN_EXCHANGE=getattr(settings, 'LOCKDOWN_GEONODE', False),
+        LOGIN_WARNING=getattr(settings, 'LOGIN_WARNING', False),
+        LOGIN_WARNING_TEXT=getattr(settings, 'LOGIN_WARNING_TEXT', "''")
     )
 
     return defaults

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -474,3 +474,25 @@ if ENABLE_SOCIAL_LOGIN:
         AUTHENTICATION_BACKENDS += (
             'exchange.auth.backends.geoaxis.GeoAxisOAuth2',
         )
+        
+        LOGIN_WARNING = True
+        LOGIN_WARNING_TEXT = '<p>You are accessing a U.S. Government (USG) Information System (IS) that is provided ' \
+                     'for USG-authorized use only.  By using this IS ' \
+                     '(which includes any device attached to this IS), you ' \
+                     'consent to the following conditions:</p><ul><li>The USG routinely intercepts, and monitors ' \
+                     'communications on this IS for purposes including, but not limited to, penetration testing, ' \
+                     'COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement ' \
+                     '(LE), and counterintelligence (CI) investigations.</li><li>At any time, the USG may inspect ' \
+                     'and seize data stored on this IS.</li><li>Communications using, or data stored on, ' \
+                     'this IS are ' \
+                     'not private, are subject to routine monitoring, interception, and search, ' \
+                     'and may be disclosed ' \
+                     'or used for any USG-authorized purpose.</li></ul><p>This IS includes security measures ' \
+                     '(e.g., authentication and access controls) to protect USG interests -- not for your personel ' \
+                     'benefit or privacy.  Notwithstanding the above, using this IS does not constitute consent to ' \
+                     'PM, LE, or CI investigative searching or monitoring of the content of privileged ' \
+                     'communications, ' \
+                     'or work product, related to personal representation or services by attorneys, ' \
+                     'psychotherapists, ' \
+                     'or clergy, and their assistants.  Such communications and work product are private and ' \
+                     'confidential.  See User Agreement for details.</p>'

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -474,25 +474,20 @@ if ENABLE_SOCIAL_LOGIN:
         AUTHENTICATION_BACKENDS += (
             'exchange.auth.backends.geoaxis.GeoAxisOAuth2',
         )
-        
+
         LOGIN_WARNING = True
-        LOGIN_WARNING_TEXT = '<p>You are accessing a U.S. Government (USG) Information System (IS) that is provided ' \
-                     'for USG-authorized use only.  By using this IS ' \
-                     '(which includes any device attached to this IS), you ' \
-                     'consent to the following conditions:</p><ul><li>The USG routinely intercepts, and monitors ' \
-                     'communications on this IS for purposes including, but not limited to, penetration testing, ' \
-                     'COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement ' \
-                     '(LE), and counterintelligence (CI) investigations.</li><li>At any time, the USG may inspect ' \
-                     'and seize data stored on this IS.</li><li>Communications using, or data stored on, ' \
-                     'this IS are ' \
-                     'not private, are subject to routine monitoring, interception, and search, ' \
-                     'and may be disclosed ' \
-                     'or used for any USG-authorized purpose.</li></ul><p>This IS includes security measures ' \
-                     '(e.g., authentication and access controls) to protect USG interests -- not for your personel ' \
-                     'benefit or privacy.  Notwithstanding the above, using this IS does not constitute consent to ' \
-                     'PM, LE, or CI investigative searching or monitoring of the content of privileged ' \
-                     'communications, ' \
-                     'or work product, related to personal representation or services by attorneys, ' \
-                     'psychotherapists, ' \
-                     'or clergy, and their assistants.  Such communications and work product are private and ' \
-                     'confidential.  See User Agreement for details.</p>'
+        LOGIN_WARNING_TEXT = '''<p>You are accessing a U.S. Government (USG) Information System (IS) that is provided
+            for USG-authorized use only.  By using this IS (which includes any device attached to this IS), you
+            consent to the following conditions:</p><ul><li>The USG routinely intercepts, and monitors
+            communications on this IS for purposes including, but not limited to, penetration testing,
+            COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement
+            (LE), and counterintelligence (CI) investigations.</li><li>At any time, the USG may inspect
+            and seize data stored on this IS.</li><li>Communications using, or data stored on,
+            this IS are not private, are subject to routine monitoring, interception, and search,
+            and may be disclosed or used for any USG-authorized purpose.</li></ul><p>This IS includes security measures
+            (e.g., authentication and access controls) to protect USG interests -- not for your personal
+            benefit or privacy.  Notwithstanding the above, using this IS does not constitute consent to
+            PM, LE, or CI investigative searching or monitoring of the content of privileged communications,
+            or work product, related to personal representation or services by attorneys, psychotherapists,
+            or clergy, and their assistants.  Such communications and work product are private and
+            confidential.  See User Agreement for details.</p>'''

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -67,6 +67,27 @@ CLASSIFICATION_BACKGROUND_COLOR = os.getenv(
 )
 CLASSIFICATION_LINK = os.getenv('CLASSIFICATION_LINK', None)
 
+# login warning
+LOGIN_WARNING_ENABLED = str2bool(os.getenv('LOGIN_WARNING_ENABLED', 'False'))
+
+if LOGIN_WARNING_ENABLED:
+    LOGIN_WARNING_TEXT = os.getenv('LOGIN_WARNING_TEXT', '''<p>You are accessing a U.S. Government (USG)
+        Information System (IS) that is provided
+        for USG-authorized use only.  By using this IS (which includes any device attached to this IS), you
+        consent to the following conditions:</p><ul><li>The USG routinely intercepts, and monitors
+        communications on this IS for purposes including, but not limited to, penetration testing,
+        COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement
+        (LE), and counterintelligence (CI) investigations.</li><li>At any time, the USG may inspect
+        and seize data stored on this IS.</li><li>Communications using, or data stored on,
+        this IS are not private, are subject to routine monitoring, interception, and search,
+        and may be disclosed or used for any USG-authorized purpose.</li></ul><p>This IS includes security measures
+        (e.g., authentication and access controls) to protect USG interests -- not for your personal
+        benefit or privacy.  Notwithstanding the above, using this IS does not constitute consent to
+        PM, LE, or CI investigative searching or monitoring of the content of privileged communications,
+        or work product, related to personal representation or services by attorneys, psychotherapists,
+        or clergy, and their assistants.  Such communications and work product are private and
+        confidential.  See User Agreement for details.</p>''')
+
 # registration
 EMAIL_HOST = os.getenv('EMAIL_HOST', None)
 EMAIL_PORT = os.getenv('EMAIL_PORT', None)
@@ -474,20 +495,3 @@ if ENABLE_SOCIAL_LOGIN:
         AUTHENTICATION_BACKENDS += (
             'exchange.auth.backends.geoaxis.GeoAxisOAuth2',
         )
-
-        LOGIN_WARNING = True
-        LOGIN_WARNING_TEXT = '''<p>You are accessing a U.S. Government (USG) Information System (IS) that is provided
-            for USG-authorized use only.  By using this IS (which includes any device attached to this IS), you
-            consent to the following conditions:</p><ul><li>The USG routinely intercepts, and monitors
-            communications on this IS for purposes including, but not limited to, penetration testing,
-            COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement
-            (LE), and counterintelligence (CI) investigations.</li><li>At any time, the USG may inspect
-            and seize data stored on this IS.</li><li>Communications using, or data stored on,
-            this IS are not private, are subject to routine monitoring, interception, and search,
-            and may be disclosed or used for any USG-authorized purpose.</li></ul><p>This IS includes security measures
-            (e.g., authentication and access controls) to protect USG interests -- not for your personal
-            benefit or privacy.  Notwithstanding the above, using this IS does not constitute consent to
-            PM, LE, or CI investigative searching or monitoring of the content of privileged communications,
-            or work product, related to personal representation or services by attorneys, psychotherapists,
-            or clergy, and their assistants.  Such communications and work product are private and
-            confidential.  See User Agreement for details.</p>'''

--- a/exchange/templates/account/login.html
+++ b/exchange/templates/account/login.html
@@ -29,7 +29,7 @@
     <div class="row">
         {% if ENABLE_FACEBOOK_LOGIN %}
     	<div class="col-sm-4">
-            <a href="{% url 'social:begin' 'facebook' %}">
+            <a href="{% url 'social:begin' 'facebook' %}?next={{ request.path }}">
                 <div class="facebook-btn btn btn-md bg-ms btn-block">
                     <i class="fa fa-facebook"></i> Log In with Facebook
                 </div>
@@ -38,7 +38,7 @@
         {% endif %}
         {% if ENABLE_GOOGLE_LOGIN %}
         <div class="col-sm-4">
-            <a href="{% url 'social:begin' 'google-oauth2' %}">
+            <a href="{% url 'social:begin' 'google-oauth2' %}?next={{ request.path }}">
                 <div class="google-btn btn btn-md bg-ms btn-block">
                     <i class="fa fa-google"></i> Log In with Google
                 </div>
@@ -47,7 +47,7 @@
         {% endif %}
         {% if ENABLE_GEOAXIS_LOGIN %}
          <div class="col-sm-4">
-            <a href="{% url 'social:begin' 'geoaxis' %}">
+            <a href="{% url 'social:begin' 'geoaxis' %}?next={{ request.path }}">
                 <div class="google-btn btn btn-md bg-ms btn-block">
                     Log In with GeoAxis
                 </div>

--- a/exchange/templates/account/login.html
+++ b/exchange/templates/account/login.html
@@ -8,7 +8,7 @@
 
 {% block body_outer %}
 <div class="page-header">
-  <h2>{% trans "Log in to an existing account" %}</h2>
+  <h2>{% trans "Log In to an existing account" %}</h2>
 </div>
 <div class="row">
   <div class="col-md-8">
@@ -22,37 +22,29 @@
         <p><a href="{% url "forgot_username" %}">{% trans "Forgot your username?" %}</a></p>
         <p><a href="{% url "account_password_reset" %}">{% trans "Forgot your password?" %}</a></p>
       </div>
-      <button type="submit" class="btn btn-primary">{% trans "Log in" %}</button>
+      <button type="submit" class="btn btn-primary">{% trans "Log In" %}</button>
     </form>
+
   </div>
+
    {% if ENABLE_SOCIAL_LOGIN %}
-    <div class="row">
+
+    <div class="col-md-4" style="float:right;">
+
         {% if ENABLE_FACEBOOK_LOGIN %}
-    	<div class="col-sm-4">
-            <a href="{% url 'social:begin' 'facebook' %}?next={{ request.path }}">
-                <div class="facebook-btn btn btn-md bg-ms btn-block">
-                    <i class="fa fa-facebook"></i> Log In with Facebook
-                </div>
+            <a class="btn-facebook btn-social btn bg-ms btn-block" href="{% url 'social:begin' 'facebook' %}?{{ redirect_field_name }}={{ redirect_field_value }}">
+                <i class="fa fa-facebook"></i> Log In with Facebook
             </a>
-        </div>
         {% endif %}
         {% if ENABLE_GOOGLE_LOGIN %}
-        <div class="col-sm-4">
-            <a href="{% url 'social:begin' 'google-oauth2' %}?next={{ request.path }}">
-                <div class="google-btn btn btn-md bg-ms btn-block">
-                    <i class="fa fa-google"></i> Log In with Google
-                </div>
+            <a class="btn-google btn-social btn bg-ms btn-block" href="{% url 'social:begin' 'google-oauth2' %}?{{ redirect_field_name }}={{ redirect_field_value }}">
+                <i class="fa fa-google"></i> Log In with Google
             </a>
-        </div>
         {% endif %}
         {% if ENABLE_GEOAXIS_LOGIN %}
-         <div class="col-sm-4">
-            <a href="{% url 'social:begin' 'geoaxis' %}?next={{ request.path }}">
-                <div class="google-btn btn btn-md bg-ms btn-block">
-                    Log In with GeoAxis
-                </div>
+            <a class="btn-geoaxis btn-social btn bg-ms btn-block" href="{% url 'social:begin' 'geoaxis' %}?{{ redirect_field_name }}={{ redirect_field_value }}">
+                <i class="fa fa-lock"></i> Log In with GeoAxis
             </a>
-        </div>
         {% endif %}
     </div>
     {% endif %}

--- a/exchange/templates/account/login.html
+++ b/exchange/templates/account/login.html
@@ -4,9 +4,30 @@
 {% load i18n %}
 {% load bootstrap_tags %}
 
-{% block head_title %}{% trans "Log in" %}{% endblock %}
+{% block head_title %}{% trans "Log In" %}{% endblock %}
 
 {% block body_outer %}
+{% if LOGIN_WARNING %}
+<div class="login-root">
+
+    <h1>Welcome to {{ SITE_NAME }}!</h1>
+    <div class="login-warning">
+        {% autoescape off %}
+            {{ LOGIN_WARNING_TEXT }}
+        {% endautoescape%}
+    </div>
+    {% if ENABLE_GEOAXIS_LOGIN %}
+    <a class="btn-geoaxis btn-social btn bg-ms btn-block" href="{% url 'social:begin' 'geoaxis' %}?{{ redirect_field_name }}={{ redirect_field_value }}">
+        <i class="fa fa-lock"></i> Accept and Log In with GeoAxis
+    </a>
+    {% else %}
+    <a href="#" class="btn-geoaxis btn-social btn bg-ms btn-block" data-toggle="modal" data-target="#SigninModal" role="button" >
+        <i class="fa fa-lock"></i>  {% trans "Accept and Log In with Exchange" %}
+    </a>
+    {% endif %}
+</div>
+
+{% else %}
 <div class="page-header">
   <h2>{% trans "Log In to an existing account" %}</h2>
 </div>
@@ -49,6 +70,7 @@
     </div>
     {% endif %}
 </div>
+{% endif %}
 {% endblock %} 
  
  

--- a/exchange/themes/static/theme/css/site_base.css
+++ b/exchange/themes/static/theme/css/site_base.css
@@ -137,7 +137,7 @@ h1, h2, h3, h4, h5, h6 {
     border-color: rgba(0,0,0,0.2);
 }
 
-.btn-google:hover{
+.btn-google:hover {
     color:#fff;
     background-color:#c23321;
     border-color:rgba(0,0,0,0.2);
@@ -150,7 +150,7 @@ h1, h2, h3, h4, h5, h6 {
     border-color: rgba(0,0,0,0.2);
 }
 
-.btn-facebook:hover{
+.btn-facebook:hover {
     color:#fff;
     background-color:#2d4373;
     border-color:rgba(0,0,0,0.2);
@@ -165,7 +165,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 
-.btn-geoaxis:hover{
+.btn-geoaxis:hover {
     color:#fff;
     background-color:#008000;
     border-color:rgba(0,0,0,0.2);
@@ -183,6 +183,7 @@ h1, h2, h3, h4, h5, h6 {
     text-decoration: none;
     font-weight: 300;
     font-size: 15px;
+    max-width: 270px;
 }
 
 .btn-social>:first-child {
@@ -195,4 +196,19 @@ h1, h2, h3, h4, h5, h6 {
     font-size: 1.6em;
     text-align: center;
     border-right: 1px solid rgba(0,0,0,0.2);
+}
+
+.login-warning {
+    width: 100%;
+    margin: 1em 0;
+    padding: 2em;
+    background-color: #fff;
+    text-align: left;
+    box-shadow: 0 0 0 5px rgba(0,0,0,.03), inset 0 0 0 1px;
+}
+
+.login-root {
+    align-items: center;
+    flex-direction: column;
+    display: flex;
 }

--- a/exchange/themes/static/theme/css/site_base.css
+++ b/exchange/themes/static/theme/css/site_base.css
@@ -128,3 +128,71 @@ h1, h2, h3, h4, h5, h6 {
     outline-width: 0;
     font-size: 1.5em;
 }
+
+/* Social Login Buttons*/
+
+.btn-google {
+    color: #fff;
+    background-color: #dd4b39;
+    border-color: rgba(0,0,0,0.2);
+}
+
+.btn-google:hover{
+    color:#fff;
+    background-color:#c23321;
+    border-color:rgba(0,0,0,0.2);
+    text-decoration: none;
+}
+
+.btn-facebook {
+    color: #fff;
+    background-color: #3b5998;
+    border-color: rgba(0,0,0,0.2);
+}
+
+.btn-facebook:hover{
+    color:#fff;
+    background-color:#2d4373;
+    border-color:rgba(0,0,0,0.2);
+    text-decoration: none;
+}
+
+.btn-geoaxis {
+    color:#fff;
+    background-color: #16aa3e;
+    border-color:rgba(0,0,0,0.2);
+    text-decoration: none;
+}
+
+
+.btn-geoaxis:hover{
+    color:#fff;
+    background-color:#008000;
+    border-color:rgba(0,0,0,0.2);
+    text-decoration: none;
+}
+
+.btn-social {
+    position: relative;
+    padding-left: 44px;
+    text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 5px;
+    text-decoration: none;
+    font-weight: 300;
+    font-size: 15px;
+}
+
+.btn-social>:first-child {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 32px;
+    line-height: 34px;
+    font-size: 1.6em;
+    text-align: center;
+    border-right: 1px solid rgba(0,0,0,0.2);
+}

--- a/exchange/themes/templates/base.html
+++ b/exchange/themes/templates/base.html
@@ -129,7 +129,7 @@
                   </ul>
                 </li>
               {% else %}
-                <li><a href="#" data-toggle="modal" data-target="#SigninModal" role="button" >{% trans "Sign in" %} </a></li>
+                <li><a href="#" data-toggle="modal" data-target="#SigninModal" role="button" >{% trans "Log In" %} </a></li>
               {% endif %}
 
               <li>
@@ -220,7 +220,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-            <h4 class="modal-title" id="myModalLabel">{% trans "Sign in" %}</h4>
+            <h4 class="modal-title" id="myModalLabel">{% trans "Log In" %}</h4>
           </div>
           <form class="form-signin" role="form" action="{% url "account_login" %}?next={{ request.path }}" method="post">
             <div class="modal-body">
@@ -238,7 +238,7 @@
               </label>
             </div>
             <div class="modal-footer">
-              <button type="submit" class="btn btn-primary btn-block">{% trans "Sign in" %}</button>
+              <button type="submit" class="btn btn-primary btn-block">{% trans "Log In" %}</button>
             </div>
           </form>
         </div>

--- a/exchange/themes/templates/base.html
+++ b/exchange/themes/templates/base.html
@@ -48,6 +48,7 @@
             </button>
             <a class="navbar-brand" href="{% url "home" %}">Exchange</a>
           </div>
+          {% if not LOCKDOWN_EXCHANGE or LOCKDOWN_EXCHANGE and user.is_authenticated %}
           <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav toolbar">
               {% block tabs %}
@@ -145,6 +146,7 @@
               </li>
             </ul>
           </div> <!--/.nav-collapse -->
+          {% endif %}
         </div>
       </nav>
     {% endblock header %}


### PR DESCRIPTION
This PR does the following:

- Adds a consent page to the login workflow
- Consent page text is configurable
- Consent page supports two authentication providers 1) Exchange local and 2) GeoAxis
- Hides header nav when LOCKDOWN is enabled and displays it once the user has authenticated
- Switched text Sign in to Log In to be consistent with the rest of the application

**EXCHANGE_LOCKDOWN mode enabled and user not authenticated**

<img width="1516" alt="screen shot 2017-03-25 at 1 17 30 pm" src="https://cloud.githubusercontent.com/assets/947403/24324979/f0bb2b8a-115d-11e7-9176-d847191a4f02.png">


**EXCHANGE_LOCKDOWN enabled, LOGIN_WARNING enabled, GEOAXIS enabled and user not authenticated**

<img width="1507" alt="screen shot 2017-03-25 at 12 54 42 pm" src="https://cloud.githubusercontent.com/assets/947403/24324989/5ab08ff8-115e-11e7-8c31-d3818aec1c29.png">

**EXCHANGE_LOCKDOWN enabled, LOGIN_WARNING enabled, GEOAXIS DISABLED and user not authenticated** Defaults to username password authentication

<img width="1512" alt="screen shot 2017-03-25 at 1 07 50 pm" src="https://cloud.githubusercontent.com/assets/947403/24325009/ba748994-115e-11e7-8f05-5151e2996698.png">

<img width="1510" alt="screen shot 2017-03-25 at 1 10 24 pm" src="https://cloud.githubusercontent.com/assets/947403/24325013/c3569cf0-115e-11e7-8573-47733a63f2ce.png">


