### PR TITLE
Increasing Test Coverage

### DIFF
--- a/exchange/tests/test_get_version.py
+++ b/exchange/tests/test_get_version.py
@@ -1,0 +1,15 @@
+
+
+from exchange import __version__ as the_version, get_version
+
+from . import ExchangeTest
+
+
+class TestGetVersion(ExchangeTest):
+
+    def test_get_version(self):
+        self.assertTrue(the_version in get_version(),
+                         '%s != %s! Bad version!' % (
+                           the_version,
+                           get_version()
+                        ))

--- a/exchange/tests/themes_test.py
+++ b/exchange/tests/themes_test.py
@@ -154,3 +154,8 @@ class ThemeViewTest(ExchangeTest):
         r = self.client.get('/admin/themes/theme/add/')
 
         self.assertEqual(r.status_code, 200, 'Did not get admin theme add')
+
+        r = self.client.get('/admin/themes/theme/1/')
+        r = self.client.get('/admin/themes/theme/2/')
+
+

--- a/exchange/tests/themes_test.py
+++ b/exchange/tests/themes_test.py
@@ -7,6 +7,8 @@ from django.test import TestCase, RequestFactory
 from exchange.themes.models import Theme
 from shutil import rmtree
 
+from . import ExchangeTest
+
 test_img = os.path.join(os.path.dirname(__file__), 'test.png')
 theme_dir = os.path.join(
     settings.MEDIA_ROOT,
@@ -16,6 +18,7 @@ theme_dir = os.path.join(
 
 class MockRequest:
     pass
+
 
 request = MockRequest()
 
@@ -131,3 +134,23 @@ class ThemeTestCase(TestCase):
 
     def tearDown(self):
             rmtree(theme_dir)
+
+
+class ThemeViewTest(ExchangeTest):
+
+    def setUp(self):
+        super(ThemeViewTest, self).setUp()
+
+        self.login()
+
+    def test_model_admin(self):
+        r = self.client.get('/admin/themes/theme/')
+
+        self.assertEqual(r.status_code, 200,
+                         'Did not get admin theme list (status: %d)' % (
+                           r.status_code
+                         ))
+
+        r = self.client.get('/admin/themes/theme/add/')
+
+        self.assertEqual(r.status_code, 200, 'Did not get admin theme add')

--- a/exchange/tests/upload_test.py
+++ b/exchange/tests/upload_test.py
@@ -29,6 +29,11 @@ def parse_bbox_from_html(html):
         return [float(x) for x in bboxes[0]]
     return None
 
+class TestBBOXParser(ExchangeTest):
+
+    def test_invalid_bbox(self):
+        self.assertIsNone(parse_bbox_from_html(''), 
+                          'BBOX parser failed to fail properly')
 
 class UploaderMixin:
     # Upload a shapefile and create a new layer.
@@ -70,10 +75,9 @@ class UploaderMixin:
 
         while('redirect_to' in next_step):
             next_r = self.client.get(next_step['redirect_to'])
+            next_step = {}
             if(next_r.status_code == 200):
                 next_step = json.loads(next_r.content)
-            else:
-                next_step = {}
             time.sleep(3)
 
         # If the last "step" did not produce a url
@@ -86,16 +90,11 @@ class UploaderMixin:
 
     # Remove a layer from the list.
     #
-    # @param layerName The name of the layer, formulates the url
     # @param uri       Uri to the layer info, appends 'remove' to the end.
     #
-    def drop_layer(self, layerName=None, uri=None):
+    def drop_layer(self, uri=None):
         working_uri = uri+'/remove'
-        if(layerName is not None):
-            working_uri = '/layers/'+layerName+'/remove'
-
         drop_r = self.client.post(working_uri, follow=False)
-
         self.assertEqual(drop_r.status_code, 302,
                          "Did not return expected forwaring code!")
 

--- a/exchange/tests/views_test.py
+++ b/exchange/tests/views_test.py
@@ -3,6 +3,7 @@ import pytest
 from . import ExchangeTest
 from exchange import settings
 
+
 TEST_IMG = os.path.join(os.path.dirname(__file__), 'test.png')
 TESTDIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -275,3 +276,45 @@ class UnifiedSearchTest(ViewTestCase):
     def test_search_layer_by_id(self):
         self.url = '/api/layers/search/?id=1'
         self.doit()
+
+
+# This doesn't test a view but performs a functional
+# test on one of the views transformational objects.
+#
+class ViewFunctionTests(ViewTestCase):
+
+    def test_get_unified_search_result_objects(self):
+        from exchange.views import get_unified_search_result_objects
+
+        test_hits = [{
+            '_index': 'registry',
+            '_source': {
+                'bbox': [1,2,3,4],
+            }
+        }, {
+            '_index': 'exchange',
+            '_source': {
+                'links' : {
+                    'xml' : 'layers/exchange:dummy.xml',
+                    'png' : 'layers/exchange:dummy/thumby.png'
+                }
+            }
+        }]
+
+        test_objects = get_unified_search_result_objects(test_hits)
+
+        # validate that the bbox parses correct in 
+        # the first result.
+
+        self.assertEqual(test_objects[0]['bbox_left'], 1, 
+                         'BBOX Was not formatted correctly!')
+
+        self.assertEqual(test_objects[0]['bbox_top'], 4, 
+                         'BBOX Was not formatted correctly!')
+
+
+        # ensure the thumbnail link is generated.
+
+        self.assertEqual(test_objects[1]['thumbnail_url'],
+                         'http://172.16.238.6:8001/layers/exchange:dummy/thumby.png',
+                         'Wrong thumbnail URL (%s)' % test_objects[1]['thumbnail_url'])

--- a/exchange/tests/views_test.py
+++ b/exchange/tests/views_test.py
@@ -69,6 +69,12 @@ class LayerMetadataDetailTest(ViewTestCase):
     def test_thumb(self):
         self.postfile(TEST_IMG, 'thumbnail_image')
 
+    # Test that a back-up thumbnail gets created when
+    # uploading the new thumbnail twice.
+    def test_backup_thumbnail(self):
+        self.postfile(TEST_IMG, 'thumbnail_image')
+        self.postfile(TEST_IMG, 'thumbnail_image')
+
 
 class MapMetadataDetailTest(ViewTestCase):
     def setUp(self):
@@ -87,6 +93,10 @@ class MapMetadataDetailTest(ViewTestCase):
         self.doit()
 
     def test_thumb(self):
+        self.postfile(TEST_IMG, 'thumbnail_image')
+
+    def test_backup_thumbnail(self):
+        self.postfile(TEST_IMG, 'thumbnail_image')
         self.postfile(TEST_IMG, 'thumbnail_image')
 
 
@@ -249,4 +259,19 @@ class UnifiedSearchTest(ViewTestCase):
         self.url = '/api/base/search/' \
                    '?limit=100&offset=0&q=test&' \
                    'order_by=-popular_count'
+        self.doit()
+
+    def test_search_types(self):
+        url = '/api/%s/search/?q=test'
+        self.url = url % 'layers' 
+        self.doit()
+
+        self.url = url % 'documents' 
+        self.doit()
+
+        self.url = url % 'maps' 
+        self.doit()
+
+    def test_search_layer_by_id(self):
+        self.url = '/api/layers/search/?id=1'
         self.doit()


### PR DESCRIPTION
This is some work to generally increase the test coverage across a number of modules.

1. The unified search view was refactored slightly to support better functional testing.
2. Additional tests to increase coverage based on the above.
3. Added a way to test the get_version function.
4. New tests for the theme template changes exchange uses.