### PR TITLE
Displays category as empty instead of "[]"

### DIFF
--- a/exchange/templates/base/_resourcebase_snippet.html
+++ b/exchange/templates/base/_resourcebase_snippet.html
@@ -15,7 +15,7 @@
           {% endverbatim %}
           <button ng-if="cart && item.detail_url.indexOf('/layers/') > -1" class="btn btn-default btn-xs pull-right" ng-click="cart.toggleItem(item)"><i ng-class="cart.getFaClass(item.id)" class="fa fa-lg"></i></button>
           {% verbatim %}
-          <p class="item-meta"><span class="item-category">{{ item.category__gn_description }}</span></p>
+          <p class="item-meta"><span class="item-category">{{ item.category__gn_description == '[]' ? '' : item.category__gn_description }}</span></p>
           <h4><a href="{{ item.detail_url }}">{{ item.title }}</a></h4>
           <p class="abstract">{{ item.abstract | limitTo: 300 }}{{ item.abstract.length  > 300 ? '...' : ''}}</p>
           <div class="row">


### PR DESCRIPTION
The template now checks to see if the category is "[]" and when it is, it is displayed as "" instead, otherwise the category is display as before.