### PR TITLE
Moved to self.login() instead of default passwords.

### DIFF
--- a/exchange/tests/fileservice_test.py
+++ b/exchange/tests/fileservice_test.py
@@ -18,10 +18,6 @@ class FileItemResourceTest(ResourceTestCaseMixin, ExchangeTest):
         # without streaming_supported set to True, view endpoint will behave exactly like download
         settings.FILESERVICE_CONFIG['streaming_supported'] = True
 
-        # Create a user.
-        self.username = 'admin'
-        self.password = 'exchange'
-
         self.image_filename = 'image.jpg'
 
         self.image_file = SimpleUploadedFile(
@@ -36,7 +32,7 @@ class FileItemResourceTest(ResourceTestCaseMixin, ExchangeTest):
 
     @mock.patch('exchange.fileservice.api.open', mock_open())
     def test_upload(self):
-        self.client.login(username=self.username, password=self.password)
+        self.login()
         resp = self.client.post(self.upload_url, {'file': self.image_file}, follow=True)
         self.assertHttpCreated(resp)
 
@@ -45,19 +41,19 @@ class FileItemResourceTest(ResourceTestCaseMixin, ExchangeTest):
     def test_download(self, isfile_mock, serve_mock):
         isfile_mock.return_value = True
         serve_mock.return_value = HttpResponse('Empty Response')
-        self.client.login(username=self.username, password=self.password)
+        self.login()
         resp = self.client.get(self.download_url_template.format(self.image_filename), follow=True)
         self.assertEquals(resp.get('Content-Disposition'), 'attachment; filename="{}"'.format(self.image_filename))
 
     @mock.patch('exchange.fileservice.api.os.path.isfile')
     def test_download_not_found(self, isfile_mock):
         isfile_mock.return_value = False
-        self.client.login(username=self.username, password=self.password)
+        self.login()
         resp = self.client.get(self.download_url_template.format(self.image_filename), follow=True)
         self.assertHttpNotFound(resp)
 
     def test_view(self):
-        self.client.login(username=self.username, password=self.password)
+        self.login()
         resp = self.client.get(self.view_url_template.format(self.image_filename), follow=True)
         '''
         the view end point is meant for playing back video with random access which means the progress indicator can be
@@ -69,7 +65,7 @@ class FileItemResourceTest(ResourceTestCaseMixin, ExchangeTest):
 
     def test_upload_whitelist(self):
         settings.FILESERVICE_CONFIG['types_allowed'] = ['.txt']
-        self.client.login(username=self.username, password=self.password)
+        self.login()
         resp = self.client.post(self.upload_url, {'file': self.image_file}, follow=True)
         self.assertHttpBadRequest(resp)
 


### PR DESCRIPTION
Removed the username/password assumptions from file service test.