### PR TITLE
Add context and settings variables to handle GeoQuery search

### DIFF
--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -20,6 +20,17 @@
 
 from django.conf import settings
 from exchange.version import get_version
+import logging
+from urlparse import urlparse
+
+logger = logging.getLogger(__name__)
+
+if settings.GEOQUERY_ENABLED:
+    if settings.GEOQUERY_URL is None:
+        logger.warn('No search endpoint defined.')
+        logger.warn('GEOQUERY_ENABLED was set to True, but GEOQUERY_URL was not defined.')
+    elif urlparse(settings.GEOQUERY_URL).netloc is '':
+        logger.warn('GEOQUERY_URL improperly defined or is not a valid URL.')
 
 
 def resource_variables(request):
@@ -38,7 +49,11 @@ def resource_variables(request):
         MAP_PREVIEW_LAYER=getattr(settings, 'MAP_PREVIEW_LAYER', "''"),
         LOCKDOWN_EXCHANGE=getattr(settings, 'LOCKDOWN_GEONODE', False),
         LOGIN_WARNING=getattr(settings, 'LOGIN_WARNING_ENABLED', False),
-        LOGIN_WARNING_TEXT=getattr(settings, 'LOGIN_WARNING_TEXT', "''")
+        LOGIN_WARNING_TEXT=getattr(settings, 'LOGIN_WARNING_TEXT', "''"),
+        NOMINATIM_ENABLED=getattr(settings, 'NOMINATIM_ENABLED', True),
+        NOMINATIM_URL=getattr(settings, 'NOMINATIM_URL', '//nominatim.openstreetmap.org'),
+        GEOQUERY_ENABLED=getattr(settings, 'GEOQUERY_ENABLED', False),
+        GEOQUERY_URL=getattr(settings, 'GEOQUERY_URL', None)
     )
 
     return defaults

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -284,7 +284,7 @@ ES_ENGINE = os.environ.get(
     'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine'
 )
 HAYSTACK_SEARCH = str2bool(os.getenv('HAYSTACK_SEARCH', 'False'))
-if ES_UNIFIED_SEARCH == True:
+if ES_UNIFIED_SEARCH:
     HAYSTACK_SEARCH = True
 if HAYSTACK_SEARCH:
     HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
@@ -508,3 +508,12 @@ if ENABLE_SOCIAL_LOGIN:
         AUTHENTICATION_BACKENDS += (
             'exchange.auth.backends.geoaxis.GeoAxisOAuth2',
         )
+
+# MapLoom search options
+NOMINATIM_URL = os.environ.get('NOMINATIM_URL', '//nominatim.openstreetmap.org')
+GEOQUERY_ENABLED = os.environ.get('GEOQUERY_ENABLED', False)
+GEOQUERY_URL = os.environ.get('GEOQUERY_URL', None)
+if GEOQUERY_ENABLED:
+    NOMINATIM_ENABLED = False
+else:
+    NOMINATIM_ENABLED = True

--- a/exchange/tests/core_test.py
+++ b/exchange/tests/core_test.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from exchange.core.models import ThumbnailImage
 from exchange.core.context_processors import resource_variables
 from shutil import rmtree
+from urlparse import urlparse
 
 test_img = os.path.join(os.path.dirname(__file__), 'test.png')
 thumbs_dir = os.path.join(
@@ -93,3 +94,24 @@ class resource_variablesTestCase(TestCase):
             'GEOAXIS_ENABLED',
             self.defaults
         )
+        self.assertIn(
+            'NOMINATIM_ENABLED',
+            self.defaults
+        )
+        self.assertIn(
+            'GEOQUERY_ENABLED',
+            self.defaults
+        )
+        self.assertIn(
+            'NOMINATIM_URL',
+            self.defaults
+        )
+        self.assertIn(
+            'GEOQUERY_URL',
+            self.defaults
+        )
+
+        if self.defaults['GEOQUERY_ENABLED'] is True:
+            self.assertIsNotNone(self.defaults['GEOQUERY_URL'], "GEOQUERY_URL was not defined.")
+            # Minimal validation that GEOQUERY_URL is a valid URL
+            self.assertNotEqual(urlparse(self.defaults['GEOQUERY_URL']).netloc, '')


### PR DESCRIPTION
Requires https://github.com/boundlessgeo/MapLoom/pull/83 for GeoQuery search to be enabled (default settings for OSM will continue to function correctly, so it is safe to merge)