### PR TITLE
Clear Uploader Test Failures in Travis

### DIFF
--- a/docker-compose-unified-search.yml
+++ b/docker-compose-unified-search.yml
@@ -36,3 +36,4 @@ services:
             - ES_URL=http://search:9200
             - ES_UNIFIED_SEARCH=True
             - REGISTRYURL=http://172.16.238.6:8001
+            - REGISTRY_LOCAL_URL=http://172.16.238.6:8001

--- a/exchange/tests/upload_test.py
+++ b/exchange/tests/upload_test.py
@@ -9,6 +9,10 @@ import time
 
 from . import ExchangeTest
 
+import pytest
+
+from exchange import settings
+
 
 # This is a dummy exception class
 #  used to make back tracing easier.
@@ -103,6 +107,8 @@ class UploaderMixin:
 #
 # Performs various uploads and drops of layers.
 #
+@pytest.mark.skipif(settings.ES_UNIFIED_SEARCH is False,
+                    reason="Only run if using unified search")
 class UploadLayerTest(UploaderMixin, ExchangeTest):
 
     def setUp(self):


### PR DESCRIPTION
1. Added REGISTRY_LOCAL_URL configuration.  An earlier commit
   changed REGISTRYURL to REGISTRY_LOCAL_URL.
2. Added a skip-decorator to the upload tests for when
   elastic search is not enabled in the environment.