### PR TITLE
Updated thumbnail to use scale and not clip.

### DIFF
--- a/exchange/thumbnails/static/geonode/js/utils/thumbnail.js
+++ b/exchange/thumbnails/static/geonode/js/utils/thumbnail.js
@@ -24,19 +24,13 @@ var createMapThumbnail = function() {
     //   of the image.
     var thumb_w = 240, thumb_h = 180;
     var w = canvas.width(), h = canvas.height();
-    var c_x = w/2, c_y = h/2;
-    var x0 = c_x - thumb_w/2;
-    var y0 = c_y - thumb_h/2;
-
-    // then get the thumbnail from the image itself.
-    var clip = canvas[0].getContext('2d').getImageData(x0,y0,thumb_w,thumb_h);
 
     // create a temporary canvas for the 
     //  new thumbnail.
     var thumb_canvas = $('<canvas>').appendTo('body');
     thumb_canvas[0].width = thumb_w;
     thumb_canvas[0].height = thumb_h;
-    thumb_canvas[0].getContext('2d').putImageData(clip,0,0);
+    thumb_canvas[0].getContext('2d').drawImage(canvas[0], 0, 0, w, h, 0, 0, thumb_w, thumb_h);
 
     // get the PNG for saving...
     var png_data = thumb_canvas[0].toDataURL('image/png');


### PR DESCRIPTION
Previous verison of the thumbnail sampler used
clipping. The new version uses scaling to capture
the entire map view.