### PR TITLE
Fix for Primary Key Bug with Thumbnails

### DIFF
--- a/exchange/tests/thumbnail_test.py
+++ b/exchange/tests/thumbnail_test.py
@@ -109,3 +109,28 @@ class ThumbnailTest(ExchangeTest):
         test_b64 = b64encode(r.content)
         self.assertEqual(test_b64, b64encode(thumbpng),
                          'Images appear to differ.')
+
+    # Ensure that layer legends are preserved when set.
+    #
+    def test_two_layers(self):
+        png1 = open(self.get_file_path('test_thumbnail0.png'), 'rb').read()
+        png2 = open(self.get_file_path('test_thumbnail1.png'), 'rb').read()
+
+        self.client.post('/thumbnails/layers/layer1', png1,
+                         content_type='image/png')
+
+
+        self.client.post('/thumbnails/layers/layer2', png2,
+                         content_type='image/png')
+
+        r = self.client.get('/thumbnails/layers/layer1')
+        self.assertEqual(r.status_code, 200, 'failed to retrieve thumbnail')
+        data1 = r.content
+
+        r = self.client.get('/thumbnails/layers/layer2')
+        self.assertEqual(r.status_code, 200, 'failed to retrieve thumbnail')
+        data2 = r.content
+
+        self.assertEqual(data1, png1, 'Mismatch in thumbnail 1')
+        self.assertEqual(data2, png2, 'Mismatch in thumbnail 2')
+

--- a/exchange/thumbnails/views.py
+++ b/exchange/thumbnails/views.py
@@ -12,7 +12,7 @@ from base64 import b64decode
 import imghdr
 import os
 
-from .models import Thumbnail
+from .models import Thumbnail, save_thumbnail
 
 # cache the blank gif for missing images.
 TEST_DIR = os.path.dirname(__file__)
@@ -59,12 +59,7 @@ def thumbnail_view(request, objectType, objectId):
             return HttpResponse(status=400, content='Bad thumbnail format.')
 
         # if the thumbnail does not exist, create a new one.
-        thumb = Thumbnail(object_type=objectType, object_id=objectId,
-                          thumbnail_mime='image/'+image_type,
-                          thumbnail_img=image_bytes, is_automatic=False)
-
-        # save the updates
-        thumb.save()
+        save_thumbnail(objectType, objectId, 'image/'+image_type, image_bytes, False)
 
         # return a success message.
         return HttpResponse(status=201)


### PR DESCRIPTION
A slight difference between how the ORM expected the compound primary key to work and how .save was actually working has been causing some bugs when saving thumbnails.  This fixes that situation and centralizes the logic into thumbnails.models.save_thumbnail.

A new test has been added to prove that this actually fixes the problem as well.