### PR TITLE
Removed deprecated setting and allow the scope to be configurable.

### DIFF
--- a/exchange/auth/backends/geoaxis.py
+++ b/exchange/auth/backends/geoaxis.py
@@ -15,10 +15,10 @@ class GeoAxisOAuth2(BaseOAuth2):
     ID_KEY = 'user_id'
     AUTHORIZATION_URL = 'https://' + HOST + '/ms_oauth/oauth2/endpoints/oauthservice/authorize'
     ACCESS_TOKEN_URL = 'https://' + HOST + '/ms_oauth/oauth2/endpoints/oauthservice/tokens'
-    DEFAULT_SCOPE = ['UserProfile']
+    DEFAULT_SCOPE = getattr(settings, 'SOCIAL_AUTH_GEOAXIS_SCOPE', '')
     REDIRECT_STATE = False
     ACCESS_TOKEN_METHOD = 'POST'
-    SSL_PROTOCOL = ssl.PROTOCOL_TLSv1
+
     EXTRA_DATA = [
         ('refresh_token', 'refresh_token', True),
         ('user_id', 'user_id'),

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -506,6 +506,8 @@ if ENABLE_SOCIAL_LOGIN:
     SOCIAL_AUTH_GEOAXIS_KEY = os.environ.get('OAUTH_GEOAXIS_KEY', None)
     SOCIAL_AUTH_GEOAXIS_SECRET = os.environ.get('OAUTH_GEOAXIS_SECRET', None)
     SOCIAL_AUTH_GEOAXIS_HOST = os.environ.get('OAUTH_GEOAXIS_HOST', None)
+    OAUTH_GEOAXIS_SCOPES = os.environ.get('OAUTH_GEOAXIS_SCOPES', 'UserProfile.me')
+    SOCIAL_AUTH_GEOAXIS_SCOPE = map(str.strip, OAUTH_GEOAXIS_SCOPES.split(','))
     ENABLE_GEOAXIS_LOGIN = isValid(SOCIAL_AUTH_GEOAXIS_KEY)
     # GeoAxisOAuth2 will cause all login attempt to fail if SOCIAL_AUTH_GEOAXIS_HOST is None
     if ENABLE_GEOAXIS_LOGIN:

--- a/exchange/templates/account/login.html
+++ b/exchange/templates/account/login.html
@@ -22,7 +22,7 @@
     </a>
     {% else %}
     <a href="#" class="btn-geoaxis btn-social btn bg-ms btn-block" data-toggle="modal" data-target="#SigninModal" role="button" >
-        <i class="fa fa-lock"></i>  {% trans "Accept and Log In with Exchange" %}
+        <i class="fa fa-lock"></i>  {% trans "Accept and Log In with " %}{{ SITE_NAME }}
     </a>
     {% endif %}
 </div>


### PR DESCRIPTION
This PR applies a fix to an issue found in the latest version of Exchange where the incorrect Scope was sent to GeoAxis causing the request to fail. The Scope can now be configured via settings.