### PR TITLE
Configure the key and secret

### DIFF
--- a/exchange/auth/backends/geoaxis.py
+++ b/exchange/auth/backends/geoaxis.py
@@ -12,6 +12,8 @@ from django.conf import settings
 class GeoAxisOAuth2(BaseOAuth2):
     name = 'geoaxis'
     HOST = getattr(settings, 'SOCIAL_AUTH_GEOAXIS_HOST', 'localhost')
+    CLIENT_KEY = getattr(settings, 'SOCIAL_AUTH_GEOAXIS_KEY', '')
+    CLIENT_SECRET = getattr(settings, 'SOCIAL_AUTH_GEOAXIS_SECRET', '')
     ID_KEY = 'user_id'
     AUTHORIZATION_URL = 'https://' + HOST + '/ms_oauth/oauth2/endpoints/oauthservice/authorize'
     ACCESS_TOKEN_URL = 'https://' + HOST + '/ms_oauth/oauth2/endpoints/oauthservice/tokens'
@@ -26,7 +28,7 @@ class GeoAxisOAuth2(BaseOAuth2):
     ]
     
     def auth_headers(self):
-        b64Val = base64.b64encode('3d1c9d20aced4bd1b480ef114d6b3f92:wIBhcabK')
+        b64Val = base64.b64encode('{}:{}'.format(self.CLIENT_KEY, self.CLIENT_SECRET))
         return {'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
                 'Authorization': "Basic %s" % b64Val}
     

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -163,6 +163,7 @@ INSTALLED_APPS = (
     'maploom',
     'solo',
     'exchange-docs',
+    'social_django',
 ) + ADDITIONAL_APPS + INSTALLED_APPS
 
 if OSGEO_IMPORTER_ENABLED:
@@ -466,7 +467,6 @@ if SITEURL.startswith('https'):
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 if ENABLE_SOCIAL_LOGIN:
-    INSTALLED_APPS = ('social_django',) + INSTALLED_APPS
     SOCIAL_AUTH_NEW_USER_REDIRECT_URL = '/'
 
     AUTHENTICATION_BACKENDS += (
@@ -509,7 +509,8 @@ if ENABLE_SOCIAL_LOGIN:
     OAUTH_GEOAXIS_SCOPES = os.environ.get('OAUTH_GEOAXIS_SCOPES', 'UserProfile.me')
     SOCIAL_AUTH_GEOAXIS_SCOPE = map(str.strip, OAUTH_GEOAXIS_SCOPES.split(','))
     ENABLE_GEOAXIS_LOGIN = isValid(SOCIAL_AUTH_GEOAXIS_KEY)
-    SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
+    if SITEURL.startswith('https'):
+        SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
     # GeoAxisOAuth2 will cause all login attempt to fail if SOCIAL_AUTH_GEOAXIS_HOST is None
     if ENABLE_GEOAXIS_LOGIN:
         AUTHENTICATION_BACKENDS += (

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -509,6 +509,7 @@ if ENABLE_SOCIAL_LOGIN:
     OAUTH_GEOAXIS_SCOPES = os.environ.get('OAUTH_GEOAXIS_SCOPES', 'UserProfile.me')
     SOCIAL_AUTH_GEOAXIS_SCOPE = map(str.strip, OAUTH_GEOAXIS_SCOPES.split(','))
     ENABLE_GEOAXIS_LOGIN = isValid(SOCIAL_AUTH_GEOAXIS_KEY)
+    SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
     # GeoAxisOAuth2 will cause all login attempt to fail if SOCIAL_AUTH_GEOAXIS_HOST is None
     if ENABLE_GEOAXIS_LOGIN:
         AUTHENTICATION_BACKENDS += (


### PR DESCRIPTION
This PR removes the hard-coded client key and forces https for redirect handling. Without this change, installs configured for https will fail on the redirect back to the application because the application will send http://<site_url> as the redirect. Lastly this PR allows the social_django app to be installed by default so that the models can be created during Exchange install.