### PR TITLE
added nearsight configuration

### DIFF
--- a/dev/settings.sh
+++ b/dev/settings.sh
@@ -28,4 +28,7 @@ export SOCIAL_BUTTONS='False'
 export SECRET_KEY='exchange@q(6+mnr&=jb@z#)e_cix10b497vzaav61=de5@m3ewcj9%ctc'
 export DEFAULT_ANONYMOUS_VIEW_PERMISSION='False'
 export DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION='False'
+export NEARSIGHT=True
+export DJANGO_LOG_LEVEL=DEBUG
+export PATH=$PATH:/opt/boundless/vendor/bin/:/opt/boundless/vendor/lib/
 # export WGS84_MAP_CRS=True

--- a/dev/settings.sh
+++ b/dev/settings.sh
@@ -28,7 +28,4 @@ export SOCIAL_BUTTONS='False'
 export SECRET_KEY='exchange@q(6+mnr&=jb@z#)e_cix10b497vzaav61=de5@m3ewcj9%ctc'
 export DEFAULT_ANONYMOUS_VIEW_PERMISSION='False'
 export DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION='False'
-export NEARSIGHT=True
-export DJANGO_LOG_LEVEL=DEBUG
-export PATH=$PATH:/opt/boundless/vendor/bin/:/opt/boundless/vendor/lib/
 # export WGS84_MAP_CRS=True

--- a/dev/supervisord.conf
+++ b/dev/supervisord.conf
@@ -12,7 +12,7 @@ logfile_backups=1
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [group:exchange]
-programs=geoserver,django
+programs=geoserver,django,celery
 priority=999
 
 [program:geoserver]
@@ -34,3 +34,14 @@ redirect_stderr=true
 stdout_logfile=/vagrant/dev/.logs/django.log
 stdout_logfile_maxbytes=10MB
 stdout_logfile_backups=3
+
+[program:celery]
+command=/vagrant/.venv/bin/celery -A exchange.celery_app worker
+user=vagrant
+stopasgroup=true
+redirect_stderr=true
+stdout_logfile=/vagrant/dev/.logs/celery.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=3
+
+

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -406,6 +406,23 @@ REGISTRYURL = os.environ.get('REGISTRYURL', None)
 REGISTRY_CAT = os.environ.get('REGISTRY_CAT', 'registry')
 REGISTRY_LOCAL_URL = os.environ.get('REGISTRY_LOCAL_URL', 'http://localhost:8001')
 
+# NearSight Options, adding NEARSIGHT to env will enable nearsight.
+if os.getenv('NEARSIGHT'):
+    NEARSIGHT_UPLOAD = os.getenv("NEARSIGHT_UPLOAD", '/opt/nearsight/store')
+    NEARSIGHT_LAYER_PREFIX = os.getenv("NEARSIGHT_LAYER_PREFIX", 'nearsight')
+    NEARSIGHT_CATEGORY_NAME = os.getenv('NEARSIGHT_CATEGORY_NAME', 'NearSight')
+    NEARSIGHT_GEONODE_RESTRICTIONS = os.getenv('NEARSIGHT_GEONODE_RESTRICTIONS', "NearSight Data")
+    DATABASES['nearsight'] = DATABASES['exchange_imports']
+    CACHES = locals().get('CACHES', {})
+    CACHES['nearsight'] = CACHES.get('nearsight', {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': NEARSIGHT_UPLOAD,
+    })
+    CACHES['default'] = CACHES.get('default', CACHES.get('nearsight'))
+    NEARSIGHT_SERVICE_UPDATE_INTERVAL = os.getenv("NEARSIGHT_SERVICE_UPDATE_INTERVAL", 5)
+    SSL_VERIFY = os.getenv("SSL_VERIFY", False)
+    INSTALLED_APPS += ('nearsight',)
+
 # If django-osgeo-importer is enabled, give it the settings it needs...
 if 'osgeo_importer' in INSTALLED_APPS:
     import pyproj
@@ -529,3 +546,4 @@ if GEOQUERY_ENABLED:
     NOMINATIM_ENABLED = False
 else:
     NOMINATIM_ENABLED = True
+

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -406,8 +406,8 @@ REGISTRYURL = os.environ.get('REGISTRYURL', None)
 REGISTRY_CAT = os.environ.get('REGISTRY_CAT', 'registry')
 REGISTRY_LOCAL_URL = os.environ.get('REGISTRY_LOCAL_URL', 'http://localhost:8001')
 
-# NearSight Options, adding NEARSIGHT to env will enable nearsight.
-if os.getenv('NEARSIGHT'):
+# NearSight Options, adding NEARSIGHT_ENABLED to env will enable nearsight.
+if os.getenv('NEARSIGHT_ENABLED'):
     NEARSIGHT_UPLOAD = os.getenv("NEARSIGHT_UPLOAD", '/opt/nearsight/store')
     NEARSIGHT_LAYER_PREFIX = os.getenv("NEARSIGHT_LAYER_PREFIX", 'nearsight')
     NEARSIGHT_CATEGORY_NAME = os.getenv('NEARSIGHT_CATEGORY_NAME', 'NearSight')

--- a/exchange/urls.py
+++ b/exchange/urls.py
@@ -79,6 +79,10 @@ if 'osgeo_importer' in settings.INSTALLED_APPS:
 if settings.STORYSCAPES_ENABLED:
     urlpatterns += story_urls
 
+if 'nearsight' in settings.INSTALLED_APPS:
+    from nearsight.urls import urlpatterns as nearsight_urls
+    urlpatterns += nearsight_urls
+
 # use combined registry/geonode elastic search rather than geonode search
 if settings.ES_UNIFIED_SEARCH:
     urlpatterns += [url(r'^api/(?P<resourcetype>base)/search/$',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ git+git://github.com/boundlessgeo/django-exchange-maploom.git@master#django-exch
 git+git://github.com/boundlessgeo/geonode@exchange/1.2.0#egg=geonode
 git+git://github.com/GeoNode/django-osgeo-importer@master#egg=django-osgeo-importer
 git+git://github.com/boundlessgeo/exchange-documentation@master#egg=django-exchange-docs
+git+git://github.com/venicegeo/nearsight@master#egg=nearsight
 numpy==1.11.3
 django-geonode-client==0.0.23
 dj-database-url==0.4.2


### PR DESCRIPTION
The configuration provided is an example configuration of NearSight inside of Exchange.  
Adding `NEARSIGHT` to the environment will add the nearsight URLs.
Then migrations will need to be ran.  
Lastly in order to work properly a directory needs to be provided for `NEARSIGHT_UPLOAD` with permissions given to the django server to read and write to the directory. 




























