### PR TITLE
Migration script to lengthen CSW Record URLs.

### DIFF
--- a/exchange/core/migrations/0001_initial.py
+++ b/exchange/core/migrations/0001_initial.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import datetime
+import uuid
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CSWRecord',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, serialize=False, editable=False, primary_key=True)),
+                ('status', models.CharField(default=b'Unknown', max_length=128)),
+                ('classification', models.CharField(max_length=128, blank=True)),
+                ('title', models.CharField(max_length=328)),
+                ('modified', models.DateField(default=datetime.date.today)),
+                ('creator', models.CharField(max_length=328, blank=True)),
+                ('record_type', models.CharField(max_length=128, blank=True)),
+                ('alternative', models.CharField(max_length=128, blank=True)),
+                ('abstract', models.TextField(blank=True)),
+                ('source', models.URLField()),
+                ('relation', models.CharField(max_length=128, blank=True)),
+                ('record_format', models.CharField(max_length=128, blank=True)),
+                ('bbox_upper_corner', models.CharField(default=b'85.0 180', max_length=128, blank=True)),
+                ('bbox_lower_corner', models.CharField(default=b'-85.0 -180', max_length=128, blank=True)),
+                ('contact_information', models.CharField(max_length=128, blank=True)),
+                ('gold', models.BooleanField(default=False, max_length=128)),
+                ('category', models.CharField(blank=True, max_length=128, choices=[(b'Air', b'Air (Aero)'), (b'Intelligence', b'Intelligence'), (b'Elevation', b'Elevation'), (b'HumanGeog', b'Human Geography'), (b'Basemaps', b'Basemaps'), (b'Space', b'Space'), (b'Land', b'Land (Topo)'), (b'Targeting', b'Targeting'), (b'NamesBoundaries', b'Names & Boundaries'), (b'MapsCharts', b'NGA Standard Maps & Charts'), (b'Sea', b'Sea (Maritime)'), (b'Imagery', b'Imagery/Collections'), (b'Geomatics', b'Geodesy/Geodetics Geomatics'), (b'Weather', b'Weather')])),
+                ('user', models.ForeignKey(related_name='csw_records_created', to=settings.AUTH_USER_MODEL, null=True)),
+            ],
+            options={
+                'verbose_name': 'CSW Record',
+                'verbose_name_plural': 'CSW Records',
+            },
+        ),
+        migrations.CreateModel(
+            name='ThumbnailImage',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('thumbnail_image', models.ImageField(upload_to=b'/scratch/media_root/thumbs')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+    ]

--- a/exchange/core/migrations/0002_lengthen_csw_source.py
+++ b/exchange/core/migrations/0002_lengthen_csw_source.py
@@ -1,0 +1,18 @@
+#
+# Change the URL field from 200 to 512 character max length.
+#
+
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0001_initial')
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='CSWRecord',
+            name='source',
+            field=models.URLField(max_length=512, blank=False),
+        )
+    ]

--- a/exchange/core/models.py
+++ b/exchange/core/models.py
@@ -100,7 +100,7 @@ class CSWRecord(models.Model):
     record_type = models.CharField(max_length=128, blank=True)
     alternative = models.CharField(max_length=128, blank=True)
     abstract = models.TextField(blank=True)
-    source = models.URLField(blank=False)
+    source = models.URLField(max_length=512, blank=False)
     relation = models.CharField(max_length=128, blank=True)
     record_format = models.CharField(max_length=128, blank=True)
     bbox_upper_corner = models.CharField(max_length=128,


### PR DESCRIPTION
1. Adds 0001_initial.py migration file which describes the models.
   This was needed because Django needs *something* to start from
   in migrations to define the data.
2. The 0002 migration actually lengthens the URL field.
3. The model is updated to reflect the lengthened field.

Running these requires some trickery!!!

Instead of just `migrate` we need `migrate --fake-initial` in order for this to migrate properly! The initial models were not managed by migrate; so "faking" it is requires on the initial migration intake.

```
python migrate.py migrate --fake-initial
```

