### PR TITLE
Audit username field can be null

### DIFF
--- a/exchange/audit/migrations/0002_username.py
+++ b/exchange/audit/migrations/0002_username.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2017 Boundless Spatial
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from __future__ import unicode_literals
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('audit', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='auditevent',
+            name='event',
+            field=models.CharField(max_length=16, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='auditevent',
+            name='username',
+            field=models.CharField(max_length=255, null=True),
+        ),
+    ]

--- a/exchange/audit/models.py
+++ b/exchange/audit/models.py
@@ -27,7 +27,7 @@ class AuditEvent(models.Model):
                           auto_created=True,
                           primary_key=True)
     event = models.CharField(max_length=16, null=True, blank=True)
-    username = models.CharField(max_length=255, null=False, blank=False)
+    username = models.CharField(max_length=255, null=True, blank=False)
     ip = models.GenericIPAddressField(null=True, blank=True)
     email = models.EmailField(null=True, blank=True)
     fullname = models.CharField(max_length=255, null=True, blank=True)


### PR DESCRIPTION
This change was done so users are not prompted to set a default when migrating.
Currently users are prompted when upgrading with the following:

```
System check identified some issues:

You are trying to change the nullable field 'username' on auditevent to non-nullable without a default; we can't do that (the database needs something to populate existing rows).
Please select a fix:
 1) Provide a one-off default now (will be set on all existing rows)
 2) Ignore for now, and let me handle existing rows with NULL myself (e.g. because you added a RunPython or RunSQL operation to handle NULL values in a previous data migration)
 3) Quit, and let me add a default in models.py
Select an option:
```