### PR TITLE
Add Registry Link, Lock Down Admin-only Menu Links

### DIFF
--- a/exchange/tests/__init__.py
+++ b/exchange/tests/__init__.py
@@ -21,10 +21,31 @@ class ExchangeTest(TestCase):
         global TESTDIR
         return os.path.join(TESTDIR, filename)
 
-    def login(self):
+    # The test user is a basic user, no admin/staff permissions.
+    #
+    def create_test_user(self):
         User = get_user_model()
 
-        self.client = Client()
+        test_users = User.objects.filter(
+            username='test'
+        )
+        if test_users.count() > 0:
+            self.test_user = test_users[0]
+        else:
+            self.test_user = User.objects.create_user(
+                username='test',
+                email=''
+            )
+        self.test_user.set_password('test')
+        self.test_user.save()
+
+        return ('test', 'test')
+
+    # Admin user is the overlord for the system.
+    #
+    def create_admin_user(self):
+        User = get_user_model()
+
         admin_users = User.objects.filter(
             is_superuser=True
         )
@@ -37,9 +58,19 @@ class ExchangeTest(TestCase):
             )
         self.admin_user.set_password('admin')
         self.admin_user.save()
+
+        return ('admin', 'admin')
+
+    def login(self, asTest=False):
+        if(asTest):
+            username, password = self.create_test_user()
+        else:
+            username, password = self.create_admin_user()
+
+        self.client = Client()
         logged_in = self.client.login(
-            username='admin',
-            password='admin'
+            username=username,
+            password=password
         )
         self.assertTrue(logged_in)
 

--- a/exchange/tests/csw_perms_test.py
+++ b/exchange/tests/csw_perms_test.py
@@ -1,0 +1,34 @@
+#
+# Ensure only administrative users can
+# access the CSW views.
+#
+
+from . import ExchangeTest
+
+
+class CswPermissionsTest(ExchangeTest):
+
+    def _test_url(self, url, expectedStatus):
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, expectedStatus,
+                         'Mismatched status for %s. Expected %d, got %d' % (
+                             url, expectedStatus, r.status_code
+                         ))
+
+    def test_as_test(self):
+        # login as test.
+        self.login(asTest=True)
+
+        # should get a redirect to the authentication screen.
+        self._test_url('/csw/new/', 302)
+        self._test_url('/csw/status/', 302)
+        self._test_url('/csw/status_table/', 302)
+
+    def test_as_admin(self):
+        # login as admin
+        self.login()
+
+        # these should all clear as 200s
+        self._test_url('/csw/new/', 200)
+        self._test_url('/csw/status/', 200)
+        self._test_url('/csw/status_table/', 200)

--- a/exchange/tests/csw_perms_test.py
+++ b/exchange/tests/csw_perms_test.py
@@ -32,3 +32,13 @@ class CswPermissionsTest(ExchangeTest):
         self._test_url('/csw/new/', 200)
         self._test_url('/csw/status/', 200)
         self._test_url('/csw/status_table/', 200)
+
+    def test_menus_as_test(self):
+        self.login(asTest=True)
+        r = self.client.get('/')
+        self.assertNotIn('/csw/new/', r.content, 'Found CSW Menu in Test User Login!')
+
+    def test_menus_as_admin(self):
+        self.login()
+        r = self.client.get('/')
+        self.assertIn('/csw/new/', r.content, 'No CSW Menu in Admin Login!')

--- a/exchange/themes/templates/base.html
+++ b/exchange/themes/templates/base.html
@@ -120,9 +120,12 @@
                     <li><a href="{{ user.get_absolute_url }}">{% trans "Profile" %}</a></li>
                     <li><a href="{% url "recent-activity" %}">{% trans "Recent Activity" %}</a></li>
                     <li><a href="{% url "messages_inbox" %}">{% trans "Inbox" %}</a></li>
+                    {% if user.is_staff %}
                     <li role="separator" class="divider"></li>
+                    <li><a href="{% url "insert_csw" %}">Registry</a></li>
                     <li><a href="{% url "admin:index" %}">Admin</a></li>
                     <li><a href="{{ GEOSERVER_BASE_URL }}">GeoServer</a></li>
+                    {% endif %}
                     <li role="separator" class="divider"></li>
                     <li><a href="{% url "help" %}">{% trans "Help" %}</a></li>
                     <li role="separator" class="divider"></li>

--- a/exchange/views.py
+++ b/exchange/views.py
@@ -9,6 +9,7 @@ from geonode.layers.views import _resolve_layer, _PERMISSION_MSG_METADATA
 from django.http import HttpResponseRedirect, HttpResponse, JsonResponse
 from django.core.urlresolvers import reverse
 from django.core.serializers import serialize
+from django.contrib.admin.views.decorators import staff_member_required
 from exchange.core.models import ThumbnailImage, ThumbnailImageForm, CSWRecordForm, CSWRecord
 from geonode.base.models import TopicCategory
 from exchange.tasks import create_new_csw
@@ -62,6 +63,7 @@ def geoserver_reverse_proxy(request):
     return HttpResponse(req.content, content_type='application/xml')
 
 
+@staff_member_required
 def insert_csw(request):
     if request.method == 'POST':
         form = CSWRecordForm(request.POST)
@@ -80,6 +82,7 @@ def insert_csw(request):
                               context_instance=RequestContext(request))
 
 
+@staff_member_required
 def csw_status(request):
     format = request.GET.get('format', "")
     records = CSWRecord.objects.filter(user=request.user)
@@ -94,6 +97,7 @@ def csw_status(request):
                                   context_instance=RequestContext(request))
 
 
+@staff_member_required
 def csw_status_table(request):
     records = CSWRecord.objects.filter(user=request.user)
 


### PR DESCRIPTION
1. Added a registry link that goes to the "insert_csw" URL.
2. Changed templates to hide Registry, Admin, GeoServer from users without permission to use them.
3. Added supporting tests to verify the above.

Issues
NODE-868