### PR TITLE
add time filtering for dataset extent

### DIFF
--- a/exchange/views.py
+++ b/exchange/views.py
@@ -306,19 +306,13 @@ def unified_elastic_search(request, resourcetype='base'):
             {'range': {'layer_date': {'lte': date_end}}})
         search = search.query(q)
 
-    if extent_start and extent_end:
-        q = Q(
-                {'range': {'temporal_extent_start': {'lte': extent_end}}}
-            ) & Q(
-                {'range': {'temporal_extent_end': {'gte': extent_start}}}
-            )
-        search = search.query(q)
-    elif extent_start:
+    if extent_start:
         q = Q(
                 {'range': {'temporal_extent_end': {'gte': extent_start}}}
             )
         search = search.query(q)
-    elif extent_end:
+
+    if extent_end:
         q = Q(
                 {'range': {'temporal_extent_start': {'lte': extent_end}}}
             )


### PR DESCRIPTION
Adds temporal extent search to the api. To automatically fill the temporal extent on import, this requires PR #274. 

Adds extent__range, extent__lte, and extent__gte parameters to the api. Does not add elements to the UI.

This searches against the range of data such that if any part of the range in the data intersects the given range it will match.

NODE-872