### PR TITLE
Fixed Thumbnail URLs to match new API.

### DIFF
--- a/exchange/themes/templates/index.html
+++ b/exchange/themes/templates/index.html
@@ -67,7 +67,11 @@
       <div ng-app="featured">
         <div ng-repeat="item in featured | limitTo:4">
           <div class="col-md-3">
-            <a href="{{ item.detail_url }}"><img ng-src="{{ item.thumbnail_url }}" /></a>
+            <a href="{{ item.detail_url }}">
+              <img class="thumbnail" ng-if="item.detail_url.indexOf('map') >= 0" src="/thumbnails/maps/{{ item.id }}" />
+              <img class="thumbnail" ng-if="item.detail_url.indexOf('document') >= 0" src="/thumbnails/maps/{{ item.id }}" />
+              <img class="thumbnail" ng-if="item.detail_url.indexOf('layer') >= 0" src="/thumbnails/{{ item.detail_url }}" />
+            </a>
             <h4>{{ item.title | limitTo: 20 }}{{item.title.length > 20 ? '...' : ''}}</h4>
           </div>
         </div>


### PR DESCRIPTION
Featured content thumbnails were missed in the API update.

This fixes that oversight.

![image](https://cloud.githubusercontent.com/assets/1282291/25719110/f3d00324-30cd-11e7-94c3-48b5c044ad2c.png)
