### PR TITLE
Fix for the feature content thumbnails.

### DIFF
--- a/exchange/themes/templates/index.html
+++ b/exchange/themes/templates/index.html
@@ -68,7 +68,7 @@
         <div ng-repeat="item in featured | limitTo:4">
           <div class="col-md-3">
             <a href="{{ item.detail_url }}">
-              <img class="thumbnail" src="/thumbnails/{{ item.detail_url }}" />
+              <img class="thumbnail" src="/thumbnails{{ item.detail_url }}" />
             </a>
             <h5>{{ item.title | limitTo: 20 }}{{item.title.length > 20 ? '...' : ''}}</h5>
           </div>


### PR DESCRIPTION
As `detail_url` includes a leading "/", this removes the double "//" created
when defining the src for the thumbnail.

Refs: NODE-915