### PR TITLE
Improvements to uploader to fix layer confusion.

### DIFF
--- a/exchange/static/osgeo_importer/importer.js
+++ b/exchange/static/osgeo_importer/importer.js
@@ -1,0 +1,584 @@
+'use strict';
+
+(function() {
+
+  var httpService_ = null;
+  var layerService_ = null;
+  var q_ = null;
+
+  angular.module('osgeoImporter.uploader', [
+      'ngResource',
+      'ui.bootstrap',
+      'osgeoImporter.factories',
+      'angularFileUpload',
+      'ngCookies',
+      'mgo-angular-wizard'
+  ])
+
+  .config(function($interpolateProvider, $httpProvider, $sceDelegateProvider) {
+    $httpProvider.defaults.xsrfCookieName = 'csrftoken';
+    $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
+  })
+
+  .provider('layerService', function() {
+
+    this.$get = function($http, $q) {
+      httpService_ = $http;
+      q_ = $q;
+      layerService_ = this;
+      return this;
+    };
+
+    this.validateConfigurationOptions = function(layer) {
+      layer.configuration_options = layer.configuration_options || {};
+
+      if (!layer.hasOwnProperty('index') === true) {
+          layer['index'] = 0;
+      }
+
+      var checkStartDate = layer.configuration_options.hasOwnProperty('start_date') && layer.configuration_options.start_date != "";
+      var checkEndDate = layer.configuration_options.hasOwnProperty('end_date') && layer.configuration_options.end_date != "";
+      var dates = [];
+      layer.configuration_options.convert_to_date = [];
+
+      if (layer.configuration_options.always_geogig === true) {
+          layer.configuration_options.geoserver_store = {'type': 'geogig'};
+
+          if (layer.configuration_options.editable == false) {
+              layer.configuration_options.permissions = {'users': {'AnonymousUser': ['download_resourcebase', 'view_resourcebase']}};
+          }
+      } else {
+          if (layer.configuration_options.editable === true) {
+              layer.configuration_options.geoserver_store = {'type': 'geogig'};
+          } else {
+              delete layer.configuration_options.geoserver_store;
+          }
+      }
+
+      if (layer.configuration_options.editable === true) {
+         layer.configuration_options.geoserver_store = {'type': 'geogig'};
+      } else {
+         delete layer.configuration_options.geoserver_store;
+      }
+
+      if ((checkStartDate === true || checkEndDate == true)
+          && layer.configuration_options.configureTime === true) {
+          for (var i = 0; i < layer.fields.length; i++) {
+
+              var fieldType = layer.fields[i]['type'];
+                if (fieldType === 'Date' || fieldType === 'DateTime') {
+                    dates.push(layer.fields[i]['name']);
+                }
+          }
+
+          if (checkStartDate === true && dates.indexOf(layer.configuration_options['start_date']) == -1) {
+            layer.configuration_options.convert_to_date.push(layer.configuration_options['start_date']);
+          }
+
+          if (checkEndDate === true && dates.indexOf(layer.configuration_options['end_date']) == -1) {
+            layer.configuration_options.convert_to_date.push(layer.configuration_options['end_date']);
+          }
+      } else {
+          layer.configuration_options['start_date'] = null;
+          layer.configuration_options['end_date'] = null;
+        }
+
+      return layer;
+
+    };
+
+    this.configureUpload = function(layer) {
+      var deferredResponse = q_.defer();
+      this.validateConfigurationOptions(layer);
+      httpService_.post(layer.resource_uri + 'configure/', layer.configuration_options).success(function(data, status) {
+        // extend current object with get request to resource_uri
+        deferredResponse.resolve(layerService_.update(layer));
+      }).error(function(data, status) {
+          var error = 'Error configuring layer.';
+          if (data.hasOwnProperty('error_message')) {
+              error = data.error_message;
+          }
+          deferredResponse.reject(error, data, status);
+        });
+      return deferredResponse.promise;
+    };
+
+    this.layerFailure = function(layer) {
+        return layer.status === 'FAILURE';
+      };
+
+    this.layerSuccessful = function(layer) {
+      return layer.status === 'SUCCESS';
+    };
+
+    this.layerProcessing = function(layer) {
+      return layer.status === 'PENDING' || layer.status === 'STARTED';
+    };
+
+    this.layerComplete = function(layer) {
+      return layerService_.layerSuccessful(layer) || layerService_.layerFailure(layer);
+    };
+
+    this.update = function(layer) {
+      var deferredResponse = q_.defer();
+      httpService_.get(layer.resource_uri).success(function(data, status) {
+            deferredResponse.resolve(angular.extend(layer, data));
+        });
+      return deferredResponse.promise;
+    };
+
+  })
+
+  .controller('uploadList', function($scope, UploadedData, $rootScope) {
+    $scope.uploads = [];
+    $scope.loading = true;
+    $scope.currentPage = 0;
+    $scope.offset = 0;
+    $scope.limit = 10;
+
+
+    function getUploads(query) {
+
+        if (query == null) {
+            query = {offset: $scope.offset, limit: $scope.limit, user__username: $scope.user}
+        }
+
+        UploadedData.query(query).$promise.then(function(data) {
+            $scope.uploads = data.objects;
+            $scope.offset = data.meta.offset;
+            $scope.totalItems = data.meta.total_count;
+            $scope.loading = false;
+        });
+    }
+
+    $scope.init = function(user) {
+      $scope.user = user;
+      getUploads();
+    };
+
+    $rootScope.$on('upload:complete', function(event, args) {
+        if (args.hasOwnProperty('id')) {
+            getUploads();
+        }
+    });
+
+    $scope.pageChanged = function() {
+      $scope.offset = ($scope.currentPage - 1) * $scope.limit;
+      var query = {offset: $scope.offset, limit: $scope.limit};
+      getUploads(query);
+    };
+
+   })
+  .controller('ImportController', function ($scope, $uibModal, $log, $q, UploadedData) {
+
+      $scope.errors = [];
+      $scope.animationsEnabled = true;
+
+      /* Check to see if there are any other layers in the 
+       * data base that have already been created of too similar
+       * of a nature. 
+       *
+       * This matches the file name and feature count but could
+       * but tuned further down the road.
+       */
+      function checkForSimilar(layer) {
+        return UploadedData.query({
+            file_name: layer.file_name
+        }).$promise.then(function(data) {
+            var looks_okay = true;
+            var similar_layer = null;
+            for(var i = 0, ii = data.objects.length; looks_okay && i < ii; i++) {
+                // If a layer has the same name and feature count as 
+                //  a layer already uploaded, warn the user.
+                if(data.objects[i].layers 
+                   && data.objects[i].layers[0]
+                   && data.objects[i].layers[0].feature_count === layer.feature_count) {
+                    looks_okay = false;
+                    similar_layer = data.objects[i].layers[0].layer_name;
+                }
+            }
+
+            // TODO: This would look better as a uibModal.
+            if(!looks_okay) {
+                var error_msg = 'This layer looks to have already been uploaded as ' + similar_layer;
+                error_msg += ', continue?';
+                if(!confirm(error_msg)) {
+                    return $q.reject();
+                }
+            }
+
+            return true;
+        });
+      }
+
+
+      // TODO: Refactor args into a config object.
+      $scope.open = function (layer, templateUrl, modalImage, staticUrl, default_config, appendTo, shapefile_link, csv_link) {
+        checkForSimilar(layer).then(function() {
+            // TODO: the confirm message should be translated,
+            //        this module is missing a lot of translation directives.
+            var modalInstance = $uibModal.open({
+                animation: $scope.animationsEnabled,
+                templateUrl: templateUrl || 'importWizard.html',
+                controller: 'WizardController',
+                windowClass: 'wizard-modal-window',
+                resolve: {
+                    layer: function () {
+                        return layer;
+                    },
+                    modalImage: function () {
+                        return modalImage;
+                    },
+                    staticUrl: function () {
+                        return staticUrl;
+                    },
+                    default_config: function () {
+                      return default_config;
+                    },
+                    appendTo: function () {
+                        return appendTo;
+                    },
+                    shapefile_link: function () {
+                        return shapefile_link;
+                    },
+                    csv_link: function () {
+                        return csv_link;
+                    }
+                }
+            });
+
+            modalInstance.result.then(function (selectedItem) {
+              $scope.selected = selectedItem;
+            }, function () {
+              $log.info('Modal dismissed at: ' + new Date());
+            });
+        });
+        
+      };
+
+      $scope.toggleAnimation = function () {
+        $scope.animationsEnabled = !$scope.animationsEnabled;
+      };
+
+  })
+
+  .controller('WizardController', function ($scope, $modalInstance, layer, layerService, $interval, modalImage, staticUrl, default_config, appendTo, shapefile_link, csv_link) {
+      $scope.appendTo = appendTo;
+      $scope.layer = layer;
+      $scope.errors = false;
+      $scope.errorMessages = [];
+      $scope.modalImage = modalImage;
+      $scope.staticUrl = staticUrl;
+      $scope.shapefile_link = shapefile_link;
+      $scope.csv_link = csv_link;
+      $scope.default_config = angular.fromJson(default_config);
+      $scope.layerSet = ($scope.layer != null).toString();
+      $scope.defaultPermissions = {'users':{'AnonymousUser':['change_layer_data', 'download_resourcebase', 'view_resourcebase']}};
+      var stop;
+
+      $scope.setDefaults = function() {
+        if ($scope.layer == null) {
+            return
+        }
+
+        if ($scope.default_config !== null && $scope.default_config !== undefined) {
+          $scope.layer.configuration_options = $scope.default_config;
+        } else {
+          $scope.layer.configuration_options = {'always_geogig': true, 'configureTime': true, 'editable': true, 'convert_to_date': [], 'index': 0 };
+        }
+
+        if ($scope.layer.hasOwnProperty('name') && !($scope.layer.configuration_options.hasOwnProperty('name'))) {
+            $scope.layer.configuration_options.name = $scope.layer.name;
+        }
+
+        if ($scope.layer.configuration_options.permissions == null) {
+            $scope.layer.configuration_options.permissions = $scope.defaultPermissions;
+        }
+      };
+
+      $scope.appending = function(asString) {
+          var appending = ($scope.appendTo != null && $scope.appendTo !== false);
+
+          if (asString === true) {
+              return appending.toString()
+          }
+
+          return appending;
+
+      };
+
+      $scope.setLayer = function(layer) {
+        $scope.layer = layer;
+
+        if (($scope.appending()) === true) {
+            $scope.layer.configuration_options.appendTo = $scope.appendTo;
+        }
+
+        $scope.setDefaults();
+      };
+
+      $scope.setDefaults();
+
+      $scope.timeEnabled = function(asString) {
+        if ($scope.layer == null) {
+            return false;
+        }
+
+        if ($scope.layer.configuration_options.configureTime !== true) {
+         //Angular wizard 'wz-disabled' disables a wizard screen when it receives 'true' (string) as a value.
+         if (asString === true) {
+          return 'true';
+         }
+          return true;
+        }
+      };
+
+      $scope.ok = function () {
+        $modalInstance.dismiss('cancel');
+      };
+
+      $scope.cancel = function () {
+        $modalInstance.dismiss('cancel');
+      };
+
+      $scope.stopPolling = function() {
+          if (angular.isDefined(stop)) {
+            $interval.cancel(stop);
+            stop = undefined;
+          }
+        };
+
+      $scope.importLayer = function () {
+        // Stop if we're already polling
+        if (angular.isDefined(stop)) {
+          return;
+        }
+        $scope.processing = true;
+        layerService.configureUpload($scope.layer).then(function(newLayer) {
+          stop = $interval(function() {
+              layerService.update(newLayer).then(function(updatedLayer){
+                if (layerService.layerComplete(updatedLayer)) {
+                    $scope.stopPolling();
+                    $scope.processing = false;
+                    $scope.errors = layerService.layerFailure(updatedLayer);
+                    $scope.success = layerService.layerSuccessful(updatedLayer);
+                }
+              })
+          }, 2000);
+          },function(reason) {
+          $scope.errors = true;
+          $scope.errorMessages.push(reason);
+          $scope.processing = false;
+        });
+      }
+
+    })
+
+    .controller('UploaderController', function ($scope,  FileUploader, $cookies, $rootScope, UploadedData
+                                                ) {
+      $scope.uploader = new FileUploader({'url': '/uploads/new/json',
+          autoUpload: true,
+          headers:{'X-CSRFToken': $cookies['csrftoken']}
+      });
+
+      $scope.reset = function() {
+          $scope.errors = [];
+          $scope.uploadSuccessful = false;
+          // TODO: Implement this:
+          $scope.uploadInProgress = false;
+      };
+
+      $scope.reset();
+
+      $scope.uploader.onCompleteItem = function(fileItem, response, status, headers) {
+        $scope.reset();
+        if (response.hasOwnProperty('errors')) {
+          $scope.uploadSuccessful = false;
+          $scope.errors = response.errors;
+        } else {
+          UploadedData.query({id: response.id}).$promise.then(function(response){
+              $scope.setLayer(response['layers'][0]);
+          });
+          $scope.uploadSuccessful = true;
+          $rootScope.$broadcast('upload:complete', response);
+        }
+      };
+
+      $scope.ok = function () {
+        $modalInstance.dismiss('cancel');
+      };
+
+      $scope.cancel = function () {
+        $modalInstance.dismiss('cancel');
+      };
+    })
+
+  .directive('upload',
+      function($http, UploadedData) {
+        return {
+          restrict: 'E',
+          replace: true,
+          templateUrl: function(elem,attrs) {
+           return attrs.templateUrl || '/static/osgeo_importer/partials/upload.html'
+          },
+          scope: {
+              upload: '=uploadObject',
+              i: '=', //passes the index of the object, used to delete uploads
+              staticUrl: '@'
+          },
+          link: function(scope, element, attrs) {
+              scope.showImportOptions = false;
+              scope.layers = [];
+              scope.canGetFields = true;
+              scope.showImportWaiting = false;
+              scope.showDetails = false;
+
+              scope.allLayersImported = function() {
+                for (var i = 0; i < scope.layers.length; i++) {
+                    if (scope.layers[i].geonode_layer === {}){
+                        return false
+                    }
+                }
+                return true;
+              };
+
+              scope.deleteLayer = function(index) {
+                  var id = scope.upload.id;
+                  UploadedData.delete({id: id}, function() {
+                     console.log(scope.$parent);
+
+                     scope.$parent.uploads.splice(index, 1);
+
+                  });
+              };
+
+              scope.getFields = function() {
+                  if (scope.canGetFields !== true) {
+                      return;
+                  }
+                  scope.showImportWaiting = true;
+                  $http.get('/uploads/fields/' + scope.upload.id, {}).success(function(data, status) {
+                      scope.layers = data;
+                      scope.showImportWaiting = false;
+                      scope.canGetFields = false;
+
+                }).error(function(data, status) {
+                   scope.showImportWaiting = false;
+                   scope.configuring = false;
+                   scope.hasError = true;
+                  });
+              };
+
+          }
+        };
+      })
+
+  .directive('layerInUpload',
+      function($http) {
+        return {
+          restrict: 'C',
+          replace: false,
+          scope: true,
+          // The linking function will add behavior to the template
+          link: function(scope, element, attrs) {
+              scope.configuring = false;
+              scope.hasError = false;
+              scope.complete = false;
+              scope.importOptions = {configureTime: true, editable: true, convert_to_date: []};
+
+              scope.isImported = function() {
+                  return scope.status === 'SUCCESS';
+              };
+
+              function validateImportOptions(){
+                  var desc = scope.layer;
+                  var layer = scope.layer;
+
+                  layer.configuration_options = layer.configuration_options || {};
+
+                  if (!layer.hasOwnProperty('index') === true) {
+                      layer['index'] = 0;
+                  }
+
+                  var checkStartDate = layer.configuration_options.hasOwnProperty('start_date') && layer.configuration_options.start_date != "";
+                  var checkEndDate = layer.configuration_options.hasOwnProperty('end_date') && layer.configuration_options.end_date != "";
+                  var dates = [];
+                  layer.configuration_options.convert_to_date = [];
+
+                  if ((checkStartDate === true || checkEndDate == true)
+                      && layer.configuration_options.configureTime === true) {
+                      for (var i = 0; i < desc.fields.length; i++) {
+
+                          var fieldType = desc.fields[i]['type'];
+                            if (fieldType === 'Date' || fieldType === 'DateTime') {
+                                dates.push(desc.fields[i]['name']);
+                            }
+                      }
+
+                      if (checkStartDate === true && dates.indexOf(layer.configuration_options['start_date']) == -1) {
+                        layer.configuration_options.convert_to_date.push(layer.configuration_options['start_date']);
+                      }
+
+                      if (checkEndDate === true && dates.indexOf(layer.configuration_options['end_date']) == -1) {
+                        layer.configuration_options.convert_to_date.push(layer.configuration_options['end_date']);
+                      }
+                  } else {
+                      layer.configuration_options['start_date'] = null;
+                      layer.configuration_options['end_date'] = null;
+                  }
+              }
+
+              scope.isValid = function() {
+                  return scope.layer.configuration_options.configureTime === false ||  (scope.layer.configuration_options.configureTime === true
+                      && (scope.layer.configuration_options.start_date != null || scope.layer.configuration_options.end_date != null));
+              };
+
+              scope.hasFailure = function() {
+                return scope.layer.status === 'FAILURE';
+              };
+
+              scope.successful = function() {
+                return scope.layer.status === 'SUCCESS';
+              };
+
+              scope.processing = function() {
+                  return scope.layer.status === 'PENDING' || scope.layer.status === 'STARTED';
+              };
+
+              scope.complete = function() {
+                  return scope.successful() || scope.layer.geonode_layer != null || scope.hasFailure();
+              };
+
+              function update(){
+                  $http.get(scope.layer.resource_uri).success(function(data, status) {
+                        console.log(scope.layer, data);
+                        scope.layer = angular.extend(scope.layer, data);
+
+                        if (scope.processing() !== false) {
+                            setTimeout(function() {
+                                update();
+                            }, 2000);
+                            console.log(scope.layer.status);
+                        }
+                    });
+              }
+
+
+              scope.configureUpload = function() {
+                  alert('what');
+                  scope.configuring = true;
+                  validateImportOptions();
+                  $http.post(scope.layer.resource_uri + 'configure/', scope.layer.configuration_options).success(function(data, status) {
+                    // extend current object with get request to resource_uri
+                    console.log('configuration started');
+                    update();
+                }).error(function(data, status) {
+                   scope.configuring = false;
+                   scope.hasError = true;
+                  });
+              }
+          }
+        };
+      });
+
+})();

--- a/exchange/static/osgeo_importer/partials/upload.html
+++ b/exchange/static/osgeo_importer/partials/upload.html
@@ -1,0 +1,121 @@
+<div class="well well-sm" style="border-radius: 0">
+    <div class="row upload" ng-cloak>
+            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 section-box">
+                <div class="import-head" ng-click="showDetails=!showDetails">
+                    <div class="import-title light-bold">
+                        {{ upload.name || "[multiple files]" }}
+                        <span class="pull-right"><i ng-show="'{{upload.all_layers_imported}}' === 'True'" class="fa fa-check pull-right" style="color:#3D9970;"></i></span>
+                    </div>
+                    <div class="section-box-subtitle">
+                        <div class="user-data-metadata">
+                                {{upload.date | date:"MMM d yyyy HH:mm:ss"}}
+                                <span class="pull-right">{{upload.file_size }}</span>
+                            </div>
+                    </div>
+                </div>
+                <div>
+                <div>
+
+                        <div class="row" ng-show="showDetails">
+                            <div class="col-md-12">
+                                <hr style="margin-top: 5px"/>
+                                <!--{% if not upload.all_layers_imported %}-->
+                                <!--<div class="light-bold">Layers</div>-->
+
+                                <div class="col-xs-10 col-sm-10 col-md-10 col-lg-10 col-xs-offset-1 col-sm-offset-1 col-md-offset-1 col-lg-offset-1 layer-in-upload" ng-repeat="layer in upload.layers">
+                                    <div class="layer-upload-name">
+                                        <span>{{layer.layer_name || layer.file_name}}</span>
+                                        <span ng-show="layer.layer_name && layer.layer_name != layer.file_name"> (in {{layer.file_name}})</span>
+                                    </div>
+                                    <hr/>
+                                    <div class="row">
+                                        <div class="layer-upload-details col-md-12">
+                                            <div>
+                                                <span class="col-md-3 layer-upload-field-name">File Type</span>
+                                                <span class="col-md-9">{{layer.file_type || upload.file_type || "UNKNOWN" }}</span>
+                                            </div>
+                                            <div ng-show="layer.feature_count">
+                                                <span class="col-md-3 layer-upload-field-name">Features</span>
+                                                <span class="col-md-9">{{layer.feature_count | number : 0}}</span>
+                                            </div>
+                                            <div>
+                                                <span class="col-md-3 layer-upload-field-name">Status</span>
+                                                <span class="col-md-9">{{layer.status || "UNKNOWN" }}</span>
+                                            </div>
+                                        </div>
+
+                                        <div class="layer-upload-field col-md-12">
+                                            <div ng-repeat="field in layer.fields">
+                                                <span class="col-md-3 layer-upload-field-name">{{field.name}}</span>
+                                                <span class="col-md-9">{{field.type}}</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-12 col-lg-12">
+                                        <span class="pull-right" ng-hide="layer.geonode_layer.title" ng-click="open(layer, staticUrl +'osgeo_importer/partials/uploadWizard.html', staticUrl + 'geonode/img/logo.png', staticUrl)" ng-controller="ImportController" style="cursor: pointer;padding-left: 15px; margin-right: -11px">
+                                            Create Layer <i class="fa fa-long-arrow-right"></i>
+                                        </span>
+
+
+                                        <span class="pull-right" ng-show="layer.geonode_layer.title"><a href="{{layer.geonode_layer.url}}" target="_self">
+                                            View Layer <i class="fa fa-long-arrow-right"></i>
+                                        </a></span>
+                                    </div>
+
+                                    <form name="importOptionsForm" class="form-horizontal import-options-form" ng-show="showImportOptions" style="border-top: 1px solid rgb(199, 199, 199);">
+
+                                        <div class="col-md-12 col-lg-12">
+                                            <br/>
+                                            <div class="form-group">
+                                                <label for="layerName" class="col-sm-3 col-xs-3 col-md-3 control-label">Layer Name:</label>
+                                                <input id="layerName" type="text" class="col-md-5" ng-model="layer.configuration_options.name" placeholder="{{layer.name}}">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="configureTime" class="col-sm-3 col-xs-3 col-md-3 control-label">Enable time:</label>
+                                                <input id="configureTime" type="checkbox" ng-model="layer.configuration_options.configureTime" checked>
+                                            </div>
+                                                <div ng-show="layer.configuration_options.configureTime">
+                                                        <div class="form-group">
+                                                            <label for="start_date" class="col-sm-3 col-xs-3 col-md-3 control-label">Start date:</label>
+                                                            <select ng-model="layer.configuration_options.start_date" class="col-md-5 col-xs-5 col-sm-5" id="start_date" ng-required='layer.configuration_options'>
+                                                                <option value="" ng-selected="'' == layer.configuration_options.start_date">--Please select a field--</option>
+                                                                <option ng-repeat="option in layer.fields" ng-selected="option.name == layer.configuration_options.start_date" value="{{option.name}}">{{option.name}}</option>
+                                                            </select>
+                                                        </div>
+                                                        <div class="form-group">
+                                                            <label for="end_date" class="col-sm-3 col-xs-3 col-md-3 control-label">End date:</label>
+                                                            <select ng-model="layer.configuration_options.end_date" class="col-md-5 col-xs-5 col-sm-5" id="end_date">
+                                                                <option value="" ng-selected="'' == layer.configuration_options.end_date">--Please select a field--</option>
+                                                                <option ng-repeat="option in layer.fields" ng-selected="option.name == layer.configuration_options.end_date" value="{{option.name}}">{{option.name}}</option>
+                                                            </select>
+                                                        </div>
+                                                </div>
+                                            <div class="form-group">
+                                                <label for="editable" class="col-sm-3 control-label">Editable:</label>
+                                                <input id="editable" type="checkbox" ng-model="layer.configuration_options.editable" checked>
+                                            </div>
+                                            <div class="col-xs-offset-2 col-sm-offset-2 col-md-offset-2 col-md-8 col-lg-8" style="padding: 10px; display: table-cell; text-align: center">
+                                                <span style="color:#FF4136;" ng-show="hasFailure()">This import has failed.  Adjust configuration above.</span>
+                                                <span style="color:#3D9970;" ng-show="successful()">The import has finished successfully. View the <a href="{{layer.geonode_layer.url}}" style="font-weight: 600">Layer</a>.</span>
+                                            </div>
+                                            <div class="btn btn-sm col-xs-offset-4 col-sm-offset-4 col-md-offset-4 col-md-3 btn-success import-button" ng-click="open(layer, staticUrl + '/osgeo_importer/partials/uploadWizard.html', staticUrl + 'geonode/img/logo.png', staticUrl)" ng-controller="ImportController" ng-class="{'disabled': !isValid()}">&gt;&gt;Import
+                                                <i class="fa" ng-class="{'fa-circle-o-notch fa-spin': processing(), 'fa-arrow-circle-right': !processing()}"></i>
+                                            </div>
+
+                                     </div>
+                                    </form>
+                                </div>
+                                <!-- {% endif %} -->
+                            </div>
+                        </div>
+                </div>
+                <div class="row" ng-show="showDetails">
+                    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 user-data-story-layer-actions">
+                        <span class="pull-left" style="cursor: pointer;"><a href="{{upload.file_url}}" target="_self"><i class="fa fa-download"></i> Download</a></span>
+                        <span class="clrs-red pull-right" ng-click="deleteLayer(i)" style="cursor: pointer;"><i class="fa fa-trash-o"></i> Delete</span>
+                    </div>
+                </div>
+              </div>
+            </div>
+        </div>
+    </div>

--- a/exchange/static/osgeo_importer/partials/uploadWizard.html
+++ b/exchange/static/osgeo_importer/partials/uploadWizard.html
@@ -1,0 +1,141 @@
+<div class="modal-header">
+        <h3 class="modal-title">{{appending() === true ? "Append data to layer" : "Create a layer"}}</h3>
+</div>
+<div class="modal-body row">
+    <div class="col-sm-12 col-md-12 col-lg-12 import-wizard-modal">
+        <wizard on-finish="importLayer()">
+
+        <wz-step title="Add Data" wz-disabled="{{appending() === true ? false : 'true'}}" class="row">
+            <h3><strong>Add Data</strong></h3>
+            <p>Instead of adding edits to data one-by-one, with Append you can bulk upload a set of edits all at once. To Append, download a blank schema below, add your features to it, and proceed with your upload here</p>
+
+            <a class="btn-link" style="display: block" href="{{shapefile_link}}" target="_self">Download Shape-file schema</a>
+            <a class="btn-link" style="display: block" href="{{csv_link}}"  target="_self">Download csv schema</a>
+
+            <div class="import-wizard-button">
+                <button class="btn" type="submit" wz-next value="Continue">Continue <i class="fa fa-arrow-circle-right"></i></button>
+            </div>
+        </wz-step>
+
+        <wz-step title="Upload" wz-disabled="{{layerSet}}" canexit="layer != null" class="row">
+            <div class="col-sm-8 col-md-8 col-lg-8 col-md-offset-2" style="padding-top: 5px; padding-left: 2px;" ng-controller="UploaderController">
+
+                <h3 ng-show="appending() === false"><strong>Upload your data.</strong></h3>
+                <p ng-show="appending() === false ">You can upload data in .csv, .geojson, .gpx, .kml, .tif, and zipped shapefile formats.</p>
+
+                <h3 ng-show="appending()"><strong>Upload your feature edits.</strong></h3>
+                <p ng-show="appending()">Upload the blank file you downloaded earlier that now has your new feature edits added. Once your append is complete, you should see all of your new features added as edits to this layer.</p>
+
+
+
+                <div style="margin: 23px 0 10px 0;">
+                    <input type="file" nv-file-select uploader="uploader"/>
+                    </div>
+
+                <div style="margin: 20px 0 10px 0;">
+
+                    <uib-progressbar type="success" ng-show="uploader.progress > 0 && uploader.progress < 100" value="uploader.progress">{{uploader.progress}}%</uib-progressbar>
+
+                    <div ng-repeat="fields in errors" class="clrs-red">
+                        <div ng-repeat="error in fields" class="clrs-red">
+                            <i class="fa fa-warning" ng-show="error"></i> {{ error }}
+                    </div>
+                </div>
+                </div>
+
+                <div class="import-wizard-button">
+                    <button class="btn" type="submit" wz-next value="Continue">Continue <i class="fa fa-arrow-circle-right"></i></button>
+                </div>
+
+            </div>
+        </wz-step>
+
+
+        <wz-step title="Name">
+            <h3><strong>Layer name.</strong></h3>
+            <form name="importOptionsForm" class="form-horizontal import-options-form">
+                <p>
+                    <i>Layer names are automatically generated to prevent conflicts during upload.  To change the name, edit the Layer's metadata after the upload process has completed.</i>
+                </p>
+                <div class="form-group">
+                    <input id="layerName" type="text" readonly="true" class=input-lg ng-model="layer.configuration_options.name">
+                </div>
+
+                <div class="import-wizard-button">
+                    <button class="btn" type="submit" wz-next value="Continue">Continue <i class="fa fa-arrow-circle-right"></i></button>
+                </div>
+            </form>
+        </wz-step>
+
+        <wz-step title="Enable Time?">
+            <img class="import-wizard-image" ng-src="{{ staticUrl }}/osgeo_importer/img/time.png"/>
+            <h3><strong>Does the dataset have time attributes?</strong></h3>
+
+            <div class="btn-group">
+                <label class="btn btn-success" ng-model="layer.configuration_options.configureTime" uib-btn-radio="true">Yes</label>
+                <label class="btn btn-success" ng-model="layer.configuration_options.configureTime" uib-btn-radio="false">No</label>
+            </div>
+
+            <div class="import-wizard-button">
+                <button class="btn" type="submit" wz-next value="Continue">Continue <i class="fa fa-arrow-circle-right"></i></button>
+            </div>
+
+        </wz-step>
+
+        <wz-step title="Configure time" wz-disabled="{{timeEnabled(true)}}">
+            <h3><strong>Configure your time attributes:</strong></h3>
+            <form name="importOptionsForm" class="form-horizontal import-options-form">
+                    <div class="form-group">
+                        <label for="start_date" class="col-sm-4 col-xs-4 col-md-4 control-label">Date field (start date):</label>
+                        <select ng-model="layer.configuration_options.start_date" class="col-md-5 col-xs-5 col-sm-5 input-md" id="start_date" ng-required='layer.configuration_options'>
+                            <option value="" ng-selected="'' == layer.configuration_options.start_date">--Please select a field--</option>
+                            <option ng-repeat="option in layer.fields" ng-selected="option.name == layer.configuration_options.start_date" value="{{option.name}}">{{option.name}}</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="end_date" class="col-sm-4 col-xs-4 col-md-4 control-label">Optional end date field:</label>
+                        <select ng-model="layer.configuration_options.end_date" class="col-md-5 col-xs-5 col-sm-5 input-md" id="end_date">
+                            <option value="" ng-selected="'' == layer.configuration_options.end_date">--Please select a field--</option>
+                            <option ng-repeat="option in layer.fields" ng-selected="option.name == layer.configuration_options.end_date" value="{{option.name}}">{{option.name}}</option>
+                        </select>
+                    </div>
+                <div class="import-wizard-button">
+                <button class="btn" type="submit" wz-next value="Continue">Continue <i class="fa fa-arrow-circle-right"></i></button>
+            </div>
+            </form>
+        </wz-step>
+        <wz-step title="Permissions" wz-disabled="{{appending(true)}}">
+            <img class="import-wizard-image" ng-src="{{ staticUrl }}/osgeo_importer/img/edit.png"/>
+            <h3><strong>Enable version history?</strong></h3>
+            <div class="btn-group">
+                <label class="btn btn-success"  ng-model='layer.configuration_options.editable' uib-btn-radio="true">Yes</label>
+                <label class="btn btn-success" ng-model='layer.configuration_options.editable' uib-btn-radio="false">No</label>
+            </div>
+            <div class="import-wizard-button">
+                <button class="btn" type="submit" wz-next value="Continue">Continue <i class="fa fa-arrow-circle-right"></i></button>
+            </div>
+        </wz-step>
+        <wz-step title="{{appending() === true ? 'Append' : 'Import'}}">
+            <h3><strong>Ok, we're ready to create the layer!</strong></h3>
+            <p ng-hide="success">Click below to import your layer.</p>
+            <div>
+                <div class="clrs-green fnt-weight-400" ng-show="success"> The import has finished successfully. View the <a href="{{layer.geonode_layer.url}}?showMetadata=true" class="fnt-weight-600" target="_self">layer</a>. </div>
+                <div class="clrs-red fnt-weight-400" ng-show="errors">Layer creation has failed.  Please adjust your configuration and try again.</div>
+            </div>
+            <div class="import-wizard-button">
+                <i class="fa fa-spinner fa-spin fa-3x" ng-show="processing"></i>
+                <button class="btn" ng-show="!processing && !success" type="submit" wz-next value="Continue">Create my layer <i class="fa fa-arrow-circle-right"></i></button>
+            </div>
+            <div>
+                <ul class="import-wizard-error-list" ng-show="errorMessages">
+                    <li class="clrs-red" style="" ng-repeat="error in errorMessages">{{error}}</li>
+                </ul>
+            </div>
+
+        </wz-step>
+    </wizard>
+    </div>
+</div>
+<div class="modal-footer">
+    <span class="pull-left modal-footer-help"><button class="btn btn-primary" type="button" ng-click="ok()">Close</button></span>
+</div>


### PR DESCRIPTION
Refs: NODE-823

1. The layer_name, which is not honoured by the uploader is
   now read-only and there is an explanation as to why it is read-only.
2. Dropped the geonode logo from the uploader as a clean-up touch.
3. As the uploader was not allowing for layers to be uploaded twice
   without generating an error, the "Create Layer" link is now
   substituted out with a "View Layer" link.
4. There is now a surface-level check to tell the user that the
   layer they are working with may already have been uploaded.

Some screenshots for posterity:
![image](https://cloud.githubusercontent.com/assets/1282291/26325669/74718c68-3efd-11e7-816d-603c0f253027.png)
![image](https://cloud.githubusercontent.com/assets/1282291/26325675/81ac6eca-3efd-11e7-8719-24d55100fbc1.png)
![image](https://cloud.githubusercontent.com/assets/1282291/26325699/983dccec-3efd-11e7-8c9d-2c6e1556c702.png)
