### PR TITLE
Have OWS links show the capabilities.

### DIFF
--- a/exchange/templates/layers/metadata_detail.html
+++ b/exchange/templates/layers/metadata_detail.html
@@ -319,7 +319,7 @@
 
         {% for link in layer.link_set.ows %}
         <dt>{{link.name}}</dt>
-        <dd><a href="{{link.url}}">Geoservice {{link.link_type}}</a></dd>
+        <dd><a href="{{link.url}}?REQUEST=GetCapabilities">Geoservice {{link.link_type}}</a></dd>
         {% endfor %}
 
     </dl>


### PR DESCRIPTION
The error shown in NODE-358 was a legitimate OGC Service
error.  It was saying, quite literally, "No request given",
this updates the metadata page to point at the server's GetCapabilities
document.  Useful for a couple of reasons:

1. The GetCapbilities link can be fed to a desktop client to
   load the data in them.
2. The GetCapabliites doucment is expressly metadata for the service
   available.