### PR TITLE
Added about tab with info about Exchange and dependent projects

### DIFF
--- a/exchange/themes/templates/about.html
+++ b/exchange/themes/templates/about.html
@@ -1,0 +1,35 @@
+{% extends "site_base.html" %}
+{% load i18n %}
+
+{% block title %} {% trans "About" %} - {{ block.super }} {% endblock %}
+
+{% block middle %}
+{% block mainbody %}
+<div class="container" style="text-align: center">
+  <h1>Boundless Exchange</h1>
+  v{{ exchange_version }}
+  <br>
+  <p>Boundless Exchange is a web-based platform for your content, built for your enterprise. It facilitates the creation, sharing, and collaborative use of geospatial data. For power users, advanced editing capabilities for versioned workflows via the web browser are included. Boundless Exchange is powered by GeoNode, GeoGig, OpenLayers, PostGIS and GeoServer. Boundless Exchange is designed as a platform for collaboration.</p>
+</div>
+<div class="container">
+  <h2>What's New</h2>
+  <!-- TODO: only display link if the Exchange instance can reach open Internet -->
+  <h4>Boundless Exchange -- <a href="https://github.com/boundlessgeo/exchange/releases/tag/v{{ exchange_version }}">{{ exchange_version }}</h4></a>
+  <p>{{ exchange_release|linebreaks }}</p>
+</div>
+<div class="container">
+  <h2>Version Details</h2>
+  <ul>
+    {% for project in projects %}
+    <div style="float: left; width: 50%"><li><h4>{{ project.name }} version: v{{ project.version }}</h4></li></div>
+    <!-- TODO: only display link if the Exchange instance can reach open Internet -->
+    <div style="float: left; width: 50%"><li><h4>{{ project.name }} code revision: {% if project.boundless_repo %}<a href="{{ project.boundless_repo }}/commit/{{ project.commit }}">{% else %}<a href="{{ project.repo }}/commit/{{ project.commit }}">{% endif %}{{ project.commit }}</a></h4></li></div>
+    {% endfor %}
+  </ul>
+</div>
+<div class="container">
+  <h2>License</h2>
+  <p>Boundless Exchange is free software licensed under GNU General Public License (version 3). Refer to the included license.txt file for the full license.</p>
+</div>
+{% endblock %}
+{% endblock %}

--- a/exchange/themes/templates/base.html
+++ b/exchange/themes/templates/base.html
@@ -101,6 +101,8 @@
                     <li><a href="{% url "account_invite_user" %}">{% trans "Invite User" %}</a></li>
                     <li><a href="{% url "group_create" %}">{% trans "Create Group" %}</a></li>
                   {% endif %}
+                  <li role="separator" class="divider"></li>
+                  <li><a href="{% url "about" %}" target="_new">{% trans "Exchange" %}</a></li>
                 </ul>
               </li>
               {% block extra_tab %}
@@ -190,6 +192,18 @@
         <div class="container">
           <div class="row">
             <div class="text-center stacked">
+              {% if theme.about_link %}
+                <a href="{{ theme.about_link }}" target="_new">
+              {% else %}
+                <a href="{% url "about" %}" target="_new">
+              {% endif %}
+              {% if theme.about_text %}
+                {{ theme.about_text }}
+              {% else %}
+                {% trans "About" %}
+              {% endif %}
+              </a>
+              &nbsp;&nbsp;|&nbsp;&nbsp;
               <span>{% trans "Powered by" %}&nbsp;&nbsp;
                 {% if theme.pb_link %}
                   <a href="{{ theme.pb_link }}" target="_new">

--- a/exchange/urls.py
+++ b/exchange/urls.py
@@ -54,6 +54,7 @@ urlpatterns = patterns(
     url(r'^csw/search/$', views.csw_arcgis_search, name='csw_arcgis_search'),
     url(r'^csw/status/$', views.csw_status, name='csw_status'),
     url(r'^csw/status_table/$', views.csw_status_table, name='csw_status_table'),
+    url(r'^about/', views.about_page, name='about')
 )
 
 if settings.REGISTRY is False:


### PR DESCRIPTION
Includes a new About tab for Boundless Exchange. The tab is accessible from the footer similarly to the Documentation page. Additionally, it is accessible in the "About" dropdown menu in the header.

The new view grabs and displays information about the community and sub projects Exchange relies on, including version numbers, contributors from Boundless, the commit hash being used, and so on. The about tab is designed to show what is new with the version of Exchange and the current versions of the dependent projects. Images below.

![image](http://i.imgur.com/DrfDrWj.png)
![image](http://i.imgur.com/ldoEukl.png)
![image](http://i.imgur.com/8XsZwUM.png)

**NOTE**: The following PR's are required for the Version Dependency section to show versions and commits correctly.

https://github.com/boundlessgeo/geonode/pull/62 [MERGED]
https://github.com/boundlessgeo/django-exchange-maploom/pull/6 [OPEN]
https://github.com/GeoNode/django-osgeo-importer/pull/159 [OPEN]
https://github.com/GeoNode/geonode-client/pull/174 [MERGED]