### PR TITLE
Update CSW form to include proper labels

### DIFF
--- a/exchange/core/forms.py
+++ b/exchange/core/forms.py
@@ -44,10 +44,10 @@ class CSWRecordForm(forms.ModelForm):
         }
 
         labels = {
-            'source': _('Service Url'),
+            'source': _('Service Endpoint Url'),
             'title': _('Title'),
             'modified': _('Date Last Modified'),
-            'creator': _('Agency'),
+            'creator': _('Agency/Office'),
             'record_type': _('Type'),
             'alternative': _('Layer Identifier'),
             'abstract': _('Abstract'),


### PR DESCRIPTION
In order to provide a better experience to the
end users, it was identified that some of the labels
should be updated to more correctly reflect the
terminology that they (end users) would use or expect
on the CSW input form.