### PR TITLE
Add place to include tracking scripts when desired

### DIFF
--- a/exchange/themes/templates/base.html
+++ b/exchange/themes/templates/base.html
@@ -24,7 +24,7 @@
       {% block extra_head %}
       {% endblock %}
     {% endblock %}
-    {% include tracking_header.html %}
+    {% include 'tracking_header.html' %}
     <!--[if IE]>
       <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
       <style>
@@ -230,7 +230,7 @@
             </div>
           </div>
         </div> <!-- /.container -->
-        {% include tracking_footer.html %}
+        {% include 'tracking_footer.html' %}
       </footer>
   {% endblock footer %}
 

--- a/exchange/themes/templates/base.html
+++ b/exchange/themes/templates/base.html
@@ -24,6 +24,7 @@
       {% block extra_head %}
       {% endblock %}
     {% endblock %}
+    {% include tracking_header.html %}
     <!--[if IE]>
       <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
       <style>
@@ -229,6 +230,7 @@
             </div>
           </div>
         </div> <!-- /.container -->
+        {% include tracking_footer.html %}
       </footer>
   {% endblock footer %}
 

--- a/exchange/themes/templates/tracking_footer.html
+++ b/exchange/themes/templates/tracking_footer.html
@@ -1,0 +1,1 @@
+<!-- Add tracking scripts here if desired -->

--- a/exchange/themes/templates/tracking_header.html
+++ b/exchange/themes/templates/tracking_header.html
@@ -1,0 +1,1 @@
+<!-- Add tracking scripts here if desired -->


### PR DESCRIPTION
For certain deploys, it is desireable to include
scripts for tracking and analytics to the Exchange
site. This commit adds tracking_header.html and
tracking_footer.html as the defacto place to put
that scripting.