### PR TITLE
Fix raster import error and don't warn about possible duplicate layers

### DIFF
--- a/exchange/importer/geonode_timeextent_handler.py
+++ b/exchange/importer/geonode_timeextent_handler.py
@@ -24,6 +24,9 @@ class GeoNodeTimeExtentHandler(ImportHandlerMixin):
         Check that geonode layer already exists
         Check that start or end time column exists
         """
+        if layer_config['raster']:
+            return False
+
         self.has_start = 'start_date' in layer_config and layer_config['start_date'] != None
         self.has_end = 'end_date' in layer_config and layer_config['end_date'] != None
         logger.debug('Can run for Configuring time extent for %s. has_start=%s, has_end=%s',

--- a/exchange/static/osgeo_importer/importer.js
+++ b/exchange/static/osgeo_importer/importer.js
@@ -199,13 +199,13 @@
             }
 
             // TODO: This would look better as a uibModal.
-            if(!looks_okay) {
-                var error_msg = 'This layer looks to have already been uploaded as ' + similar_layer;
-                error_msg += ', continue?';
-                if(!confirm(error_msg)) {
-                    return $q.reject();
-                }
-            }
+            // if(!looks_okay) {
+                // var error_msg = 'This layer looks to have already been uploaded as ' + similar_layer;
+                // error_msg += ', continue?';
+                // if(!confirm(error_msg)) {
+                    // return $q.reject();
+                // }
+            // }
 
             return true;
         });


### PR DESCRIPTION
```geonode_timeextent_handler``` will currently fail because osgeo importer does not set the layer name correctly on raster layers.
This will skip the time extent check on raster layers so publishing doesn't return an error to the user;

The warning about possible duplicate layers is shown even when a layer doesn't exist. Commenting out for now