### PR TITLE
Node 980 - Add link to publisher profile in Layer Search Card

### DIFF
--- a/exchange/templates/base/_resourcebase_snippet.html
+++ b/exchange/templates/base/_resourcebase_snippet.html
@@ -17,6 +17,7 @@
           {% verbatim %}
           <p class="item-meta"><span class="item-category">{{ item.category__gn_description == '[]' ? '' : item.category__gn_description }}</span></p>
           <h4><a href="{{ item.detail_url }}">{{ item.title }}</a></h4>
+          <p class="owner"><a href="/people/profile/{{ item.owner__username }}"><i class="fa fa-user"></i>{{ item.owner__username }}</a></p>
           <p class="abstract">{{ item.abstract | limitTo: 300 }}{{ item.abstract.length  > 300 ? '...' : ''}}</p>
           <div class="row">
             <div class="col-xs-12 item-items">

--- a/exchange/templates/base/_resourcebase_snippet.html
+++ b/exchange/templates/base/_resourcebase_snippet.html
@@ -17,7 +17,7 @@
           {% verbatim %}
           <p class="item-meta"><span class="item-category">{{ item.category__gn_description == '[]' ? '' : item.category__gn_description }}</span></p>
           <h4><a href="{{ item.detail_url }}">{{ item.title }}</a></h4>
-          <p class="owner"><a href="/people/profile/{{ item.owner__username }}"><i class="fa fa-user"></i>{{ item.owner__username }}</a></p>
+          <p class="owner"><a href="/people/profile/{{ item.owner__username }}"><i class="fa fa-user"></i> {{ item.owner__username }}</a></p>
           <p class="abstract">{{ item.abstract | limitTo: 300 }}{{ item.abstract.length  > 300 ? '...' : ''}}</p>
           <div class="row">
             <div class="col-xs-12 item-items">


### PR DESCRIPTION
It is desirable to be able to contact the publisher
of a piece of content, so that users can ask questions
of that user.

This gives a quick and convenient method to do so
on the page where users will most likely need that
information.

Currently this functionality misbehaves on the Explore
Layers page, and it's been suggested by Clarence that
we adjust that page to be a specialization of the search
page. That work will be covered in a future ticket. 