### PR TITLE
Fix issues with alerts/warnings being hidden

### DIFF
--- a/exchange/static/css/django_classification_banner_overrides.css
+++ b/exchange/static/css/django_classification_banner_overrides.css
@@ -1,3 +1,7 @@
 .navbar-fixed-top, .navbar-fixed-bottom {
     top: 20px !important;
 }
+
+.alert, .alert-warning {
+	margin-top: 20px !important;
+}


### PR DESCRIPTION
Recently user notifications were changed to be a
new alert class. This change ensures that when the
classification banner is enabled that the alert
class is shifted down enough that it's not hidden
by the nav bar.