### PR TITLE
Make release notes expandable/collapsible

### DIFF
--- a/exchange/themes/templates/about.html
+++ b/exchange/themes/templates/about.html
@@ -15,7 +15,8 @@
   <h2>What's New</h2>
   <!-- TODO: only display link if the Exchange instance can reach open Internet -->
   <h4>Boundless Exchange -- <a href="https://github.com/boundlessgeo/exchange/releases/tag/v{{ exchange_version }}">{{ exchange_version }}</h4></a>
-  <p>{{ exchange_release|linebreaks }}</p>
+  <button data-toggle="collapse" data-target="#about-info" class="btn btn-primary">Release Notes</button>
+  <div id="about-info" class="collapse">{{ exchange_release|linebreaks }}</div>
 </div>
 <div class="container">
   <h2>Version Details</h2>


### PR DESCRIPTION
Addressing feedback: Adds a button to the about page under "What's New?" which will expand to show release notes (prior, all release notes were showing by default, which were sometimes long and stretched the page).