### PR TITLE
Limit keywords filter to 15 items and allow for choice between hierar…

### DIFF
--- a/exchange/templates/search/_h_keywords_filter.html
+++ b/exchange/templates/search/_h_keywords_filter.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<nav class="filter" ng-init="select_keyword_filter('trending')">
+  <h4><a href="#" class="toggle toggle-nav"><i class="fa fa-chevron-right"></i> {% trans "Keywords" %}</a></h4>
+  <div class="nav" aria-label="tools" style="display: none;">
+    <button ng-if="keywordFilter != 'hierarchical'" type="button" class="btn btn-default" style="width: 100%" ng-click="select_keyword_filter('hierarchical')">show all (hierarchical)</button>
+    <button ng-if="keywordFilter != 'trending-all'" type="button" class="btn btn-default" style="width: 100%" ng-click="select_keyword_filter('trending-all')">show all (trending)</button>
+    <button ng-if="keywordFilter == 'trending-all'" type="button" class="btn btn-default" style="width: 100%" ng-click="select_keyword_filter('trending')">show less</button>
+  </div>
+  <br class="nav" style="display: none;">
+  <div class="nav" style="display: none;">
+    {% include "search/_hierarchical_keywords.html" %}
+    {% include "search/_trending_keywords.html" %}
+  </div>
+</nav>

--- a/exchange/templates/search/_hierarchical_keywords.html
+++ b/exchange/templates/search/_hierarchical_keywords.html
@@ -1,0 +1,1 @@
+<div id="treeview" style="width: 100%"></div>

--- a/exchange/templates/search/_trending_keywords.html
+++ b/exchange/templates/search/_trending_keywords.html
@@ -1,0 +1,14 @@
+<ul class="list-group" id="trending" style="width: 100%;">
+  {% verbatim %}
+  <div ng-if="keywordFilter == 'trending-all'">
+    <li class="list-group-item" ng-repeat="kword in keywords" data-filter="keywords__slug__in" data-value="{{kword.slug}}" ng-click="multiple_choice_listener($event); toggle_text_color($event)" style="border-color: #ddd">
+      {{ kword.slug }}
+    </li>
+  </div>
+  <div ng-if="keywordFilter == 'trending'">
+    <li class="list-group-item" ng-repeat="kword in keywords | limitTo:15" data-filter="keywords__slug__in" data-value="{{kword.slug}}" ng-click="multiple_choice_listener($event); toggle_text_color($event)" style="border-color: #ddd">
+      {{ kword.slug }}
+    </li>
+  </div>
+  {% endverbatim %}
+</ul>


### PR DESCRIPTION
…hcical tags, trending (top), or trending (all)

~~Coincides with (should be merged together): https://github.com/boundlessgeo/geonode/pull/71~~ - template changes included here now

As a note for future improvement, when switching tags views, the items do not stay "active" even though they are in the filter. So, the same keyword may incorrectly appear "inactive" until clicked again, at which point it becomes active again and is corrected. This does not impair the filtering functionality in any way, and is merely a small visual bug.

Ex: In hierarchical view, select tag "geonode" and it is added to filter. Now switch to trending, and suppose geonode is visible as one of the tags. It will not be highlighted blue ("active") even though the filter remains. The visual bug is demonstrated below with the tag "charmander".

Pictures:
![image](http://i.imgur.com/uolTs7Z.png)
![image](http://i.imgur.com/gRvRQGA.png)
![image](http://i.imgur.com/UGOEUGV.png)