### PR TITLE
Move travis to centos7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ before_install:
 
 install:
   # setup and start container
-  - docker build -t ci-exchange -f docker/travis/Dockerfile.ci .
-  - docker run -v $PWD:/opt/boundless/exchange -d -p 8000:8000 -p 8080:8080 --name ci-exchange ci-exchange
+  - docker build -t boundlessgeo/ci-exchange-el7 -f docker/travis/Dockerfile.ci .
+  - docker run -v $PWD:/opt/boundless/exchange -d -p 8000:8000 -p 8080:8080 --name ci-exchange boundlessgeo/ci-exchange-el7
   # Install chromedriver
   - wget http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
@@ -44,13 +44,13 @@ before_script:
   - "export DISPLAY=:99.0"
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
   # give services some time to start
-  - sleep 60
+  - sleep 20
 
 script:
   # basic test if django is up
   - wget http://localhost:8000
   # basic test if geoserver is up
-  - wget http://localhost:8080/geoserver/index.html
+  - wget http://localhost:8080/geoserver/web/
   # run pytests for selenium only
   - py.test tests/selenium/log_in_test.py
   # flake8 tests

--- a/docker/travis/Dockerfile.ci
+++ b/docker/travis/Dockerfile.ci
@@ -1,24 +1,29 @@
-FROM boundlessgeo/ci-exchange-el6:2.1.0b2
-
-# install geoserver
-RUN curl -o /tmp/geoserver.war \
-         https://exchange-development-war.s3.amazonaws.com/war/geoserver.war
-RUN unzip /tmp/geoserver.war -d /tmp/geoserver
-RUN chmod -Rf 755 /tmp/geoserver
+FROM centos:latest
 
 # install geonode-exchange and dependencies
 ADD . /opt/boundless/exchange
-RUN mkdir -p /opt/boundless/exchange/.storage/media/fileservice
 
-RUN echo "GEOS_LIBRARY_PATH = '/opt/boundless/vendor/lib/libgeos_c.so'" >> /opt/boundless/exchange/exchange/settings/default.py
-
-# install python dependencies
-RUN virtualenv /env && chmod -R 755 /env
-RUN PATH=$PATH:/opt/boundless/vendor/bin && /env/bin/pip install -r /opt/boundless/exchange/requirements.txt
-RUN /env/bin/pip install pytest coverage pytest-cov mock
-
-# setup django
-RUN /opt/boundless/exchange/docker/travis/setup.sh
+# install geoserver
+RUN yum clean all \
+    && yum -y install https://s3.amazonaws.com/exchange-development-yum/exchange-development-repo-1.0.0.noarch.rpm \
+    && curl -o /etc/yum.repos.d/boundlessps.repo https://yum.boundlessps.com/boundlessps.repo \
+    && yum -y install net-tools unzip git hg postgresql96-devel gdal-devel gcc gcc-c++ python-devel openldap-devel java-1.8.0-openjdk boundless-vendor-libs \
+    && ln -s /usr/pgsql-9.6/bin/pg_config /usr/bin/pg_config \
+    && curl -L -o /tmp/jetty-runner.jar http://central.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.4.6.v20170531/jetty-runner-9.4.6.v20170531.jar \
+    && curl -o /tmp/geoserver.war https://exchange-development-war.s3-accelerate.amazonaws.com/war/geoserver-2.11.war \
+    && unzip /tmp/geoserver.war -d /tmp/geoserver \
+    && chmod -Rf 755 /tmp/geoserver \
+    && echo "GEOS_LIBRARY_PATH = '/opt/boundless/vendor/lib/libgeos_c.so'" >> /opt/boundless/exchange/exchange/settings/default.py \
+    && curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py \
+    && python /tmp/get-pip.py \
+    && pip install virtualenv \
+    && virtualenv /env \
+    && chmod -R 755 /env \
+    && PATH=$PATH:/opt/boundless/vendor/bin \
+    && /env/bin/pip install -r /opt/boundless/exchange/requirements.txt \
+    && /env/bin/pip install pytest coverage pytest-cov mock \
+    && /opt/boundless/exchange/docker/travis/setup.sh \
+    && mkdir -p /opt/boundless/exchange/.storage/media/fileservice
 
 # expose ports for django and geoserver
 EXPOSE 8000 8080

--- a/docker/travis/pytests.sh
+++ b/docker/travis/pytests.sh
@@ -14,4 +14,5 @@ cd /opt/boundless/exchange
 
 # run tests
 PYTEST=True bash -c '/env/bin/py.test --cov exchange exchange/tests/'
+/env/bin/coverage xml
 bash <(curl -s https://codecov.io/bash) -cF python -t ad26f590-7fc2-4f1a-b3a4-c98b1e9cd039

--- a/exchange/tests/celery_test.py
+++ b/exchange/tests/celery_test.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 from celery import Celery
 import pytest
 
-from exchange.core.models import CSWRecordForm
+from exchange.core.forms import CSWRecordForm
 from exchange.tasks import create_new_csw
 from exchange import settings
 

--- a/exchange/tests/csw_perms_test.py
+++ b/exchange/tests/csw_perms_test.py
@@ -36,9 +36,9 @@ class CswPermissionsTest(ExchangeTest):
     def test_menus_as_test(self):
         self.login(asTest=True)
         r = self.client.get('/')
-        self.assertNotIn('/csw/new/', r.content, 'Found CSW Menu in Test User Login!')
+        self.assertNotIn('/csw', r.content, 'Found CSW Menu in Test User Login!')
 
     def test_menus_as_admin(self):
         self.login()
         r = self.client.get('/')
-        self.assertIn('/csw/new/', r.content, 'No CSW Menu in Admin Login!')
+        self.assertIn('/csw', r.content, 'No CSW Menu in Admin Login!')

--- a/exchange/tests/views_test.py
+++ b/exchange/tests/views_test.py
@@ -245,6 +245,7 @@ class UnifiedSearchTest(ViewTestCase):
 # This doesn't test a view but performs a functional
 # test on one of the views transformational objects.
 #
+@pytest.mark.skipif(settings.REGISTRYURL is None, reason="Only run if using registry")
 class ViewFunctionTests(ViewTestCase):
 
     def test_get_unified_search_result_objects(self):


### PR DESCRIPTION
This replaces the Centos6 container we used for Travis with Centos7.
As part of the changes a couple of the test were fixed, which caused the increase in coverage.