### PR TITLE
Node-953 : Enable toggling the Extent Filter on Search Page

### DIFF
--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -56,7 +56,8 @@ def resource_variables(request):
         NOMINATIM_ENABLED=getattr(settings, 'NOMINATIM_ENABLED', True),
         NOMINATIM_URL=getattr(settings, 'NOMINATIM_URL', '//nominatim.openstreetmap.org'),
         GEOQUERY_ENABLED=getattr(settings, 'GEOQUERY_ENABLED', False),
-        GEOQUERY_URL=getattr(settings, 'GEOQUERY_URL', None)
+        GEOQUERY_URL=getattr(settings, 'GEOQUERY_URL', None),
+        EXTENT_FILTER_ENABLED=getattr(settings, 'EXTENT_FILTER_ENABLED', True),
     )
 
     return defaults

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -67,6 +67,9 @@ CLASSIFICATION_BACKGROUND_COLOR = os.getenv(
 )
 CLASSIFICATION_LINK = os.getenv('CLASSIFICATION_LINK', None)
 
+# extent filter
+EXTENT_FILTER_ENABLED = str2bool(os.getenv('EXTENT_FILTER_ENABLED', 'True'))
+
 # login warning
 LOGIN_WARNING_ENABLED = str2bool(os.getenv('LOGIN_WARNING_ENABLED', 'False'))
 

--- a/exchange/templates/search/_extent_filter.html
+++ b/exchange/templates/search/_extent_filter.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{if EXTENT_FILTER_ENABLED}
+{% if EXTENT_FILTER_ENABLED %}
 <nav class="filter">
   <h4><a href="#" id="_extent_filter" class="toggle toggle-nav"><i class="fa fa-chevron-right"></i>{% trans "Extent" %}</a></h4>
   <fieldset class="nav closed">
@@ -9,4 +9,4 @@
     </div>
   </fieldset>
 </nav>
-{endif}
+{% endif %}

--- a/exchange/templates/search/_extent_filter.html
+++ b/exchange/templates/search/_extent_filter.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+{if EXTENT_FILTER_ENABLED}
+<nav class="filter">
+  <h4><a href="#" id="_extent_filter" class="toggle toggle-nav"><i class="fa fa-chevron-right"></i>{% trans "Extent" %}</a></h4>
+  <fieldset class="nav closed">
+    <div class="control-group leaflet_map">
+      <leaflet class="filter-map-container" center="map_center" defaults="defaults" layers="layers" id="filter-map">
+      </leaflet>
+    </div>
+  </fieldset>
+</nav>
+{endif}


### PR DESCRIPTION
The extent filter uses a leaflet tile map in order
to filter results based on the contents shown
in the map. This map has to reach out across the
open internet in order to properly access the
tiles.

For some deploys this is not ideal, as it is
not possible to access the open internet due
to firewalls or other restrictions. As such it
was determined that simply disabling the filter
was the best way forward for those types of
networks.