### PR TITLE
Change "Get WMS" link to use layer name not title

### DIFF
--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -312,7 +312,7 @@
     <form>
       <div class="input-group">
         <input type="text" class="form-control" readonly
-          value="{{ GEOSERVER_BASE_URL }}geonode/{{ resource }}/wms?REQUEST=GetCapabilities&" id="copy-input">
+          value="{{ GEOSERVER_BASE_URL }}geonode/{{ resource.typename }}/ows?service=wms&version=1.3.0&request=GetCapabilities" id="copy-input">
         <span class="input-group-btn">
           <button class="btn btn-primary" type="button" id="copy-button"
               data-toggle="tooltip" data-placement="button"


### PR DESCRIPTION
URL is using the title of the layer in the link,
but it should be using the GeoNode name of the
resource in GeoServer.

For Example, A layer with the Title: "Land Use",
and the Name: "landuse_30603f9f" appeared as:

https://exchange.boundlessgeo.io/geoserver/
geonode/Land%20Use/wms?REQUEST=GetCapabilities&

which is incorrect. Instead it should be:

https://exchange.boundlessgeo.io/geoserver/
geonode/landuse_30603f9f/ows?service=wms&
version=1.3.0&request=GetCapabilities