### PR TITLE
Correct OWS links for WMS/WFS/WCS

### DIFF
--- a/exchange/templates/base/_resourcebase_snippet.html
+++ b/exchange/templates/base/_resourcebase_snippet.html
@@ -37,11 +37,14 @@
                 <li ng-if="item.geogig_link">
                   <a data-toggle="tooltip" data-placement="top" tooltip title="Copy to Clipboard" ngclipboard ngclipboard-success="onCopySuccess(e);" ngclipboard-error="onCopyError(e);" data-clipboard-text="{{ item.geogig_link}}"  class="label copy-button" data-format="geogig" target="_registry">GEOGIG</a>
                 </li>
-                <li ng-if="item.subtype=='vector'">
-                  <a data-toggle="tooltip" data-placement="top" tooltip title="Copy to Clipboard" ngclipboard ngclipboard-success="onCopySuccess(e);" ngclipboard-error="onCopyError(e);" data-clipboard-text="{{ location }}/geoserver/geonode/wms?request=GetCapabilities&service=WMS&version=1.3.0&typename={{ item.typename }}"  class="label copy-button" data-format="wms" target="_registry">WMS</a>
+                <li ng-if="item.subtype=='vector' || item.subtype=='raster'">
+                  <a data-toggle="tooltip" data-placement="top" tooltip title="Copy to Clipboard" ngclipboard ngclipboard-success="onCopySuccess(e);" ngclipboard-error="onCopyError(e);" data-clipboard-text="{{ location }}/geoserver/{{ item.typename.replace(':', '/') }}/ows?request=GetCapabilities&service=WMS&version=1.3.0"  class="label copy-button" data-format="wms" target="_registry">WMS</a>
                 </li>
                 <li ng-if="item.subtype=='vector'">
-                  <a data-toggle="tooltip" data-placement="top" tooltip title="Copy to Clipboard" ngclipboard ngclipboard-success="onCopySuccess(e);" ngclipboard-error="onCopyError(e);" data-clipboard-text="{{ location }}/geoserver/geonode/ows?service=WFS&version=1.1.0&request=GetFeature&typename={{ item.typename }}&outputFormat=application/json"  class="label copy-button" data-format="wfs" target="_registry">WFS</a>
+                  <a data-toggle="tooltip" data-placement="top" tooltip title="Copy to Clipboard" ngclipboard ngclipboard-success="onCopySuccess(e);" ngclipboard-error="onCopyError(e);" data-clipboard-text="{{ location }}/geoserver/{{ item.typename.replace(':', '/') }}/ows?request=GetCapabilities&service=WFS&version=1.1.0""  class="label copy-button" data-format="wfs" target="_registry">WFS</a>
+                </li>
+                <li ng-if="item.subtype=='raster'">
+                  <a data-toggle="tooltip" data-placement="top" tooltip title="Copy to Clipboard" ngclipboard ngclipboard-success="onCopySuccess(e);" ngclipboard-error="onCopyError(e);" data-clipboard-text="{{ location }}/geoserver/{{ item.typename.replace(':', '/') }}/ows?request=GetCapabilities&service=WCS&version=2.0.1"  class="label copy-button" data-format="wcs" target="_registry">WCS</a>
                 </li>
               </ul>
             </div>

--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -312,7 +312,7 @@
     <form>
       <div class="input-group">
         <input type="text" class="form-control" readonly
-          value="{{ GEOSERVER_BASE_URL }}geonode/{{ resource.typename }}/ows?service=wms&version=1.3.0&request=GetCapabilities" id="copy-input">
+          value="{{ GEOSERVER_BASE_URL }}{{ resource.workspace }}/{{ resource.layer.name  }}/ows?service=wms&version=1.3.0&request=GetCapabilities" id="copy-input">
         <span class="input-group-btn">
           <button class="btn btn-primary" type="button" id="copy-button"
               data-toggle="tooltip" data-placement="button"


### PR DESCRIPTION
This fixes the OWS/OGC urls to point at the layer specific GetCapabilities.
Also removes the hard coded workspace, and instead either gets the workspace from the ```typename``` of from the resource's workspace attribute directly.
Added WMS and WCS for raster types.

The urls will now look like this:
https://exchange.boundlessgeo.io/geoserver/geonode/sfkjsdbf_e2f65ef5/ows?service=wms&version=1.3.0&request=GetCapabilities

https://exchange.boundlessgeo.io/geoserver/geonode/DEM/ows?request=GetCapabilities&service=WCS&version=2.0.1

https://exchange.boundlessgeo.io/geoserver/geonode/sfkjsdbf_e2f65ef5/ows?request=GetCapabilities&service=WFS&version=1.1.0
