### PR TITLE
Fix Map Metadata Detail Page button

### DIFF
--- a/exchange/templates/maps/metadata_detail.html
+++ b/exchange/templates/maps/metadata_detail.html
@@ -25,7 +25,7 @@
     {% if layer.doc_file %}
     <a href="{% url 'document_detail' docid=docid %}" class="btn btn-primary pull-right">{% trans "Return to Document" %}</a>
     {% else %}
-    <a href="{% url 'layer_detail' layername=layer.typename %}" class="btn btn-primary pull-right">{% trans "Return to Layer" %}</a>
+    <a href="{% url 'map_detail' map_id=map_id %}" class="btn btn-primary pull-right">{% trans "Return to Map" %}</a>
     {% endif %}
     <h2 class="page-title">{% trans "Metadata" %} : {{ layer.title }}</h2>
 </div>


### PR DESCRIPTION
The Map Metadata Detail Page was initially a copy
of the Layers Metadata Detail Page, and when it
was coppied over, the "Return to ..." Button wasn't
properly updated to use the Map's id, and would
return you to a blank layer search, instead of the
desired map.

Before:
![screen shot 2017-09-08 at 3 53 00 pm](https://user-images.githubusercontent.com/18401210/30233947-f7b0e604-94ad-11e7-9eae-6c007c0fd19a.png)

After:
![screen shot 2017-09-08 at 3 06 48 pm](https://user-images.githubusercontent.com/18401210/30233953-015cc9e8-94ae-11e7-81c1-f52589710917.png)
