### PR TITLE
Enable retro Remote Services workflow.

### DIFF
--- a/exchange/themes/templates/base.html
+++ b/exchange/themes/templates/base.html
@@ -61,6 +61,7 @@
                 <ul class="dropdown-menu">
                   <li><a href="{% url "layer_browse" %}">{% trans "Layers" %}</a></li>
                   <li><a href="{% url "document_browse" %}">{% trans "Documents" %}</a></li>
+                  <li><a href="{% url "services" %}">{% trans "Remote Services" %}</a></li>
                   <li role="separator" class="divider"></li>
                   <li><a href="{% url "layer_upload" %}">Upload Layer</a></li>
                   <li><a href="{% url "document_upload" %}">Upload Document</a></li>

--- a/exchange/urls.py
+++ b/exchange/urls.py
@@ -58,11 +58,6 @@ urlpatterns = patterns(
     url(r'^about/', views.about_page, name='about')
 )
 
-if settings.REGISTRY is False:
-    urlpatterns += [
-        url(r'^services(.*)$', page_not_found)
-    ]
-
 if settings.ENABLE_SOCIAL_LOGIN is True:
     urlpatterns += [
         url('', include('social_django.urls', namespace='social'))


### PR DESCRIPTION
**This PR enables the Retro Remote Services Workflow**

This PR in conjunction with the latest [WIP] commit on the 1.3.0/Geonode Branch provides better usability WRT registering remote services. The workflow includes support for ESRI REST and OGC WMS auto-population of initial metadata, extraction of underlying layers and exposes a distinct button to publish the metadata to Registry rather than doing it automatically upon save. We will phase out the existing /csw routes and the associated form.

<img width="1230" alt="screen shot 2017-09-12 at 5 52 57 pm" src="https://user-images.githubusercontent.com/947403/30351988-7a53d1ce-97e3-11e7-80d5-dd6c293e9194.png">
<img width="1286" alt="screen shot 2017-09-12 at 5 53 21 pm" src="https://user-images.githubusercontent.com/947403/30351985-7a4e9cc2-97e3-11e7-8ac9-e528b603a535.png">
<img width="1250" alt="screen shot 2017-09-12 at 5 53 34 pm" src="https://user-images.githubusercontent.com/947403/30351986-7a4ec224-97e3-11e7-9995-4ececa4af4eb.png">
<img width="1260" alt="screen shot 2017-09-12 at 5 53 46 pm" src="https://user-images.githubusercontent.com/947403/30351984-7a4d9700-97e3-11e7-9e94-c4f8f24097fc.png">
<img width="1225" alt="screen shot 2017-09-12 at 5 54 01 pm" src="https://user-images.githubusercontent.com/947403/30351987-7a4f4a32-97e3-11e7-8f94-d2b8b196ac7f.png">




