### PR TITLE
story_text.txt template added

### DIFF
--- a/exchange/storyscapes/templates/search/indexes/storyscapes/story_text.txt
+++ b/exchange/storyscapes/templates/search/indexes/storyscapes/story_text.txt
@@ -1,0 +1,1 @@
+{{ object.title }}


### PR DESCRIPTION
When rebuilding the Exchange index, if storyscapes is enabled it will fail as this template does not exist. This will allow indices to be rebuilt correctly when storyscapes is enabled. This also should provide storyscapes title as a searchable field.