### PR TITLE
Hide facets with count equal to zero

### DIFF
--- a/exchange/templates/search/_general_filters.html
+++ b/exchange/templates/search/_general_filters.html
@@ -8,7 +8,7 @@
     </a>
   </h4>
   <ul class="nav {{ facet.settings.open ? '' : 'closed' }}" id="{{ facetid }}_ul">
-      <li ng-repeat="(facetitemid, facetitem) in facet.facets" >
+      <li ng-repeat="(facetitemid, facetitem) in facet.facets" ng-if="facetitem.count > 0">
         <a data-value="{{ facetitemid }}" data-filter="{{ facetid }}"
          ng-click="multiple_choice_listener($event)" class="{{ facetitem.active}}">
          <div ng-if="facetitem.icon !== undefined" class="fa-stack fa-1g">

--- a/exchange/views.py
+++ b/exchange/views.py
@@ -561,7 +561,8 @@ def unified_elastic_search(request, resourcetype='base'):
                 bucket_key = bucket.key
                 bucket_count = bucket.doc_count
                 try:
-                    facet_results[k]['facets'][bucket_key]['count'] = bucket_count
+                    if bucket_count > 0:
+                        facet_results[k]['facets'][bucket_key]['count'] = bucket_count
                 except Exception as e:
                     facet_results['errors'] = "%s %s %s" % (k, bucket_key, e)
 
@@ -570,8 +571,11 @@ def unified_elastic_search(request, resourcetype='base'):
         facet_results['type']['facets'].update(facet_results['subtype']['facets'])
         del facet_results['subtype']
 
-    # Sort Facets
-    
+    # Remove Empty Facets
+    for item in facet_results.keys():
+        facets = facet_results[item]['facets']
+        if sum(facets[prop]['count'] for prop in facets) == 0:
+            del facet_results[item] 
 
     # Get results
     objects = get_unified_search_result_objects(results.hits.hits)


### PR DESCRIPTION
This PR hides facets that have a count equal to zero: Prior to this PR the filters would show all facets that have no match in the current search.

Example:

<img width="306" alt="screen shot 2017-10-17 at 9 15 07 am" src="https://user-images.githubusercontent.com/947403/31670133-93ea33d6-b31c-11e7-998b-f4e4b7b9d4ee.png">

Choosing Map updates the list.
<img width="311" alt="screen shot 2017-10-17 at 9 14 54 am" src="https://user-images.githubusercontent.com/947403/31670134-940c54fc-b31c-11e7-8258-cfdba4eb656c.png">
