### PR TITLE
Update Registry Dockerfile

### DIFF
--- a/docker/registry/Dockerfile
+++ b/docker/registry/Dockerfile
@@ -9,9 +9,13 @@ RUN yum -y install boundless-vendor-libs \
                    libxslt-devel \
                    make \
                    gcc \
-                   gcc-c++
+                   gcc-c++ \
+                   python27 \
+                   python27-devel \
+                   python27-setuptools \
+                   python27-virtualenv \
+                   git
 
-RUN yum install -y python27 python27-devel python27-setuptools python27-virtualenv git
 RUN /usr/local/bin/virtualenv /env && chmod -R 755 /env
 
 EXPOSE 8001


### PR DESCRIPTION
Registry Dockerfile sometimes outputs the following error when installing the packages listed inside the dockerfile:

Rpmdb checksum is invalid: dCDPT(pkg checksums): perl-version.x86_64 3:0.77-144.el6 - u
ERROR: Service 'registry' failed to build: The command '/bin/sh -c yum install -y python27 python27-devel python27-setuptools python27-virtualenv git' returned a non-zero code: 1

Moving the packages into one RUN statement alleviates this error.