### PR TITLE
Fix workspace items sometimes displaying improperly

### DIFF
--- a/exchange/static/js/search/workspace.html
+++ b/exchange/static/js/search/workspace.html
@@ -5,8 +5,8 @@
   </div>
   <ul class="list-group">
     <li class="list-group-item" ng-repeat="resource in cart.getCart().items">
-        <span class="cart-label">{{ resource.title | limitTo: 25}}{{ resource.title.length > 25 ? '...' : '' }}</span>
-        <button class="btn btn-default btn-xs pull-right" ng-click="cart.removeItem(resource)"><i class="fa fa-remove fa-lg"></i></button>
+        <span class="cart-label cartItem" title="{{ resource.title }}"> {{ resource.title }}</span>
+        <button class="btn btn-default btn-xs pull-right cartButton" ng-click="cart.removeItem(resource)"><i class="fa fa-remove fa-lg"></i></button>
     </li>
   </ul>
 </div>

--- a/exchange/themes/static/theme/css/site_base.css
+++ b/exchange/themes/static/theme/css/site_base.css
@@ -312,3 +312,13 @@ h1, h2, h3, h4, h5, h6 {
 .import-options-form {
     margin-top: 0px !important;
 }
+
+.cartItem {
+  text-overflow: ellipsis; 
+  overflow: hidden; 
+  display: block; 
+  margin-right: 25px;
+}
+.cartButton{
+  margin-top: -25px;
+}


### PR DESCRIPTION
Previously the length of the display for the name of
the item in the workspace was explicitly defined by
a number of characters. Because that section doesn't
use a monospace font, Layer names that had a collection
of wider characters like 'W' would take up more space
than Layers with names that had smaller letters like
'l'.

This change forces an explicit size for the display,
regardless of the size of the characters, causing
the names to trim at the proper length every time.

Additionally, you can now hover over a layer name
to see the full name, so if it is cut off and you
need to differentiate between two layers, you can.

Before:
<img width="1440" alt="before" src="https://user-images.githubusercontent.com/18401210/32080422-5fa811c0-ba64-11e7-87e0-16427da05943.png">

After:
<img width="1440" alt="after" src="https://user-images.githubusercontent.com/18401210/32080433-6c82b0ee-ba64-11e7-8d8e-ce148b94dde0.png">

