### PR TITLE
Use the django_id instead of id field for the map link

### DIFF
--- a/exchange/templates/base/_resourcebase_snippet.html
+++ b/exchange/templates/base/_resourcebase_snippet.html
@@ -9,8 +9,8 @@
     <div class="col-xs-12 item-container" ng-if="item.detail_url">
       <div class="col-xs-12 profile-avatar">
         <div class="col-xs-4 item-thumb">
-          <a ng-if="item.detail_url.indexOf('/maps/') > -1" href="/maps/{{item.id}}/view"><img class="thumbnail" onerror="this.src='/static/geonode/img/missing_thumb.png'" ng-src="{{ cart.getThumbnailUrl(item) }}" /></a>
-          <a ng-if="item.detail_url.indexOf('/story/') > -1" href="/story/{{item.id}}"><img class="thumbnail" onerror="this.src='/static/geonode/img/missing_thumb.png'" ng-src="{{ cart.getThumbnailUrl(item) }}" /></a>
+          <a ng-if="item.detail_url.indexOf('/maps/') > -1" href="/maps/{{item.django_id}}/view"><img class="thumbnail" onerror="this.src='/static/geonode/img/missing_thumb.png'" ng-src="{{ cart.getThumbnailUrl(item) }}" /></a>
+          <a ng-if="item.detail_url.indexOf('/story/') > -1" href="/story/{{item.django_id}}"><img class="thumbnail" onerror="this.src='/static/geonode/img/missing_thumb.png'" ng-src="{{ cart.getThumbnailUrl(item) }}" /></a>
           <a ng-if="item.detail_url.indexOf('/story/') == -1 && item.detail_url.indexOf('/maps/') == -1" href="{{ item.detail_url }}"><img class="thumbnail" onerror="this.src='/static/geonode/img/missing_thumb.png'" ng-src="{{ cart.getThumbnailUrl(item) }}" /></a>
         </div>
         <div class="col-xs-8 item-details">
@@ -19,8 +19,8 @@
           {% verbatim %}
           <p class="item-meta"><span class="item-category">{{ item.category__gn_description == '[]' ? '' : item.category__gn_description }}</span></p>
           <h4>
-            <a ng-if="item.detail_url.indexOf('/maps/') > -1" href="/maps/{{item.id}}/view">{{ item.title }}</a>
-            <a ng-if="item.detail_url.indexOf('/story/') > -1" href="/story/{{item.id}}">{{ item.title }}</a>
+            <a ng-if="item.detail_url.indexOf('/maps/') > -1" href="/maps/{{item.django_id}}/view">{{ item.title }}</a>
+            <a ng-if="item.detail_url.indexOf('/story/') > -1" href="/story/{{item.django_id}}">{{ item.title }}</a>
             <a ng-if="item.detail_url.indexOf('/layers/') > -1" href="/maps/new?layer={{item.typename}}">{{ item.title }}</a>
             <a ng-if="item.detail_url.indexOf('/story/') == -1 && item.detail_url.indexOf('/maps/') == -1 && item.detail_url.indexOf('/layers/') == -1" href="{{ item.detail_url }}">{{ item.title }}</a>
           </h4>


### PR DESCRIPTION
This corrects the map search template so that it links to the map correctly. Currently `id` refers to a uuid, not the django id. The URL wants the django id.