### PR TITLE
Fix race condition with worker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         # The only change from upstream is to add a section to the nginx config
         build: ./docker/nginx
         ports:
-          - "8084:80"
+          - "80:80"
           - "443:443"
         networks:
             internal:
@@ -197,5 +197,6 @@ services:
         # celery worker brought back up if it goes down.
         restart: always
         networks:
-            - internal
-            - external
+            internal:
+            external:
+                ipv4_address: 172.16.238.8


### PR DESCRIPTION
Previously the worker container was added to the
external network, but not assigned an explicit IP.
This resulted in a race condition where it would
take the first available IP in the range (.2) which
in turn would cause the proxy container to fail to
start because its assigned IP was already taken by
the worker.