### PR TITLE
Fix raster import

### DIFF
--- a/exchange/importer/geonode_postimport_handler.py
+++ b/exchange/importer/geonode_postimport_handler.py
@@ -9,8 +9,14 @@ class GeoNodePostImportHandler(ImportHandlerMixin):
     """
 
     def can_run(self, layer, layer_config, *args, **kwargs):
-        self.geonode_layer = Layer.objects.get(name=layer)
-        return True
+        for name in [layer, layer_config['name'], layer_config['layer_name']]:
+            try:
+                self.geonode_layer = Layer.objects.get(name=name)
+                return True
+            except:
+                pass
+
+        return False
 
     @ensure_can_run
     def handle(self, layer, layer_config, *args, **kwargs):


### PR DESCRIPTION
The importer returns a path instead of a layer name on raster import, but changing to layer name would break raster import.
```GeoNodePostImportHandler``` will try different names, and if it still can't find a layer will return ```False``` to not break layer import