### PR TITLE
Update workspace buttons layout and text

### DIFF
--- a/exchange/themes/static/theme/css/site_base.css
+++ b/exchange/themes/static/theme/css/site_base.css
@@ -314,13 +314,22 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .cartItem {
-  text-overflow: ellipsis; 
-  overflow: hidden; 
-  display: block; 
-  margin-right: 25px;
+    text-overflow: ellipsis; 
+    overflow: hidden; 
+    display: block; 
+    margin-right: 25px;
 }
-.cartButton{
-  margin-top: -25px;
+.cartButton {
+    margin-top: -25px;
+}
+
+#bulk_perms_button, #open_in_map_button {
+    white-space: pre-line;
+    width: 100%;
+}
+
+#bulk_perms_button_container, #open_in_map_button_container {
+    width: 100%;
 }
 
 /* GeoNode Viewer Feature Removal */


### PR DESCRIPTION
Previously the "Set permissions" and "Create a
Map" buttons were designed in such a way that the
text would overflow the buttons and collide with
each other at certain page widths. This behavior
isn't desired, and the buttons were redesigned to
have a clean look and feel regardless of the page
width.

Relates to GeoNode PR: https://github.com/boundlessgeo/geonode/pull/95