### PR TITLE
Fix test script to run all tests by default

### DIFF
--- a/dev/run_tests.sh
+++ b/dev/run_tests.sh
@@ -8,6 +8,5 @@ export PYTEST=1
 
 python manage.py migrate
 python manage.py collectstatic --noinput
-#py.test --ignore=tests/ --cov-report html:cov_html --cov=exchange exchange/tests/
-py.test -v --ignore=tests/ --cov=exchange exchange/tests/celery_test.py
+py.test --ignore=tests/ --cov-report html:cov_html --cov=exchange exchange/tests/
 coverage report -m


### PR DESCRIPTION
Looks like at some point someone was trying to test something specific and accidentally committed it. Just moving the commented out part back to being what is run by our `run_tests` script so it has expected behaviour.