### PR TITLE
Fixing bug with elasticsearch app

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ MAPLOOM_HOME=~/boundless/MapLoom
 
 # Settings to configure Registry and Unified Search
 ES_URL=http://search:9200
-ES_UNIFIED_SEARCH=True
+ES_SEARCH=True
 REGISTRYURL=http://172.16.238.6:8001
 
 STORYSCAPES_ENABLED=True

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -331,7 +331,7 @@ ES_URL = os.getenv('ES_URL', 'http://127.0.0.1:9200/')
 
 if ES_SEARCH:
     INSTALLED_APPS = (
-        'geonode-elasticsearch',
+        'elasticsearch_app',
     ) + INSTALLED_APPS
 
 

--- a/exchange/storyscapes/models/base.py
+++ b/exchange/storyscapes/models/base.py
@@ -97,7 +97,7 @@ class Story(ResourceBase):
     # elasticsearch_dsl indexing
     def indexing(self):
         if settings.ES_SEARCH:
-            from geonode_elasticsearch.search import StoryIndex
+            from elasticsearch_app.search import StoryIndex
             obj = StoryIndex(
                 meta={'id': self.id},
                 id=self.id,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ git+https://github.com/boundlessgeo/geonode@exchange/1.4.x#egg=geonode
 git+https://github.com/GeoNode/django-osgeo-importer@angular-1.6#egg=django-osgeo-importer
 git+https://github.com/boundlessgeo/exchange-documentation@master#egg=django-exchange-docs
 git+https://github.com/venicegeo/nearsight@master#egg=nearsight
-git+https://github.com/travislbrundage/geonode-elasticsearch@exchange#egg=geonode-elasticsearch
+git+https://github.com/boundlessgeo/geonode-elasticsearch@master#egg=geonode-elasticsearch-app
 django-jsonfield==1.0.1
 django-jsonfield-compat==0.4.4
 numpy==1.13.3


### PR DESCRIPTION
Along with: https://github.com/boundlessgeo/geonode/pull/101

Fixes bugs introduced from: https://github.com/boundlessgeo/exchange/pull/468

Remaining issue: The app is not loading on startup for some reason. If I ssh into the instance and manually install the `requirements.txt` file, the elasticsearch app finally gets installed, and with a restart to the instance, everything works fine. Does anyone have any ideas why this could be? What logs should I be looking at? My exchange logs from building the instance: https://gist.github.com/travislbrundage/6dd081d281eae4d69b1bdd3303b1cc32
My requirements.txt file: https://gist.github.com/travislbrundage/66155b5d1121687a01037db2938b3fe4#file-gistfile1-txt-L9

Side note: I have to comment out these lines to get the instance to initially come up: ```if ES_SEARCH:

    INSTALLED_APPS = (

        'elasticsearch_app',

    ) + INSTALLED_APPS``` - then ssh into it, install the `requirements.txt`, uncomment the lines, restart instance - everything works fine.

Once the above issue is solved, everything should be fixed with the elasticsearch app.