### PR TITLE
Add regions to facet search

### DIFF
--- a/exchange/views.py
+++ b/exchange/views.py
@@ -317,7 +317,8 @@ def elastic_search(request, resourcetype='base'):
     additional_facets = getattr(settings, 'ADDITIONAL_FACETS', {})
 
     facet_fields = ['type', 'subtype',
-                    'owner__username', 'keywords', 'category', 'source_host']
+                    'owner__username', 'keywords', 'category', 'source_host',
+                    'regions']
 
     if additional_facets:
         facet_fields.extend(additional_facets.keys())
@@ -351,7 +352,8 @@ def elastic_search(request, resourcetype='base'):
         'source_host': {'open': False, 'display': 'Host'},
         'owner__username': {'open': True, 'display': 'Owner'},
         'type': {'open': True, 'display': 'Type'},
-        'keywords': {'show': True}
+        'keywords': {'show': True},
+        'regions': {'show': True}
     }
 
     if additional_facets:


### PR DESCRIPTION
In the future, it may be useful to add `regions` to the fields we can search on as in the elasticsearch 6.x branch, here: https://github.com/boundlessgeo/exchange/blob/elasticsearch-6.x-compat/exchange/search/views.py#L224

However GVS requested to be able to filter by the region on the search page, hence this change.