### PR TITLE
Reorder Handler

### DIFF
--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -511,9 +511,9 @@ if 'osgeo_importer' in INSTALLED_APPS:
         'osgeo_importer.handlers.geoserver.GeoServerTimeHandler',
         'osgeo_importer.handlers.geoserver.GeoWebCacheHandler',
         'osgeo_importer.handlers.geoserver.GeoServerBoundsHandler',
+        'osgeo_importer.handlers.geoserver.GeoServerStyleHandler',
         'osgeo_importer.handlers.geoserver.GenericSLDHandler',
         'osgeo_importer.handlers.geonode.GeoNodePublishHandler',
-        'osgeo_importer.handlers.geoserver.GeoServerStyleHandler',
         'osgeo_importer.handlers.geonode.GeoNodeMetadataHandler',
         'exchange.importer.geonode_timeextent_handler.GeoNodeTimeExtentHandler',  # noqa
         'exchange.importer.geonode_postimport_handler.GeoNodePostImportHandler',  # noqa


### PR DESCRIPTION
## JIRA Ticket
BEX-1057

## Description
The symbology for an imported layer with SLD is not matching in the View Details page between the map/legend and thumbnail. The thumbnail is correctly showing the imported symbology while the map is displaying a default created style.

Changing the order of the handlers resolves the stated issue.