### PR TITLE
Adjust order of worfklow to prompt for Service metadata completion pr…

### DIFF
--- a/exchange/remoteservices/urls.py
+++ b/exchange/remoteservices/urls.py
@@ -23,6 +23,7 @@ from django.conf.urls import patterns, url
 urlpatterns = patterns(
     'exchange.remoteservices.views',
     url(r'^register/$', 'register_service', name="register_service"),
+    url(r'^(?P<service_id>\d+)/edit$', 'edit_service', name='edit_service'),
     url(r'^(?P<service_id>\d+)/rescan$', 'rescan_service',
         name='rescan_service'),
     url(r'^(?P<service_id>\d+)/harvest$', 'harvest_resources',


### PR DESCRIPTION
…ior to harvesting resources

## JIRA Ticket
N/A (GVS ticket)

## Description
Metadata form is brought up in the registration of a service workflow immediately after Exchange has had a chance to harvest the metadata from the service being registered.

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
Register a remote service. You should be prompted to fill metadata first, and then redirected to harvest resources after.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa