### PR TITLE
Show banner when using an incompatible browser, and suggest Firefox o…

### DIFF
--- a/exchange/static/css/incompatible_browser_banner_overrides.css
+++ b/exchange/static/css/incompatible_browser_banner_overrides.css
@@ -1,0 +1,33 @@
+.navbar-fixed-top, .navbar-fixed-bottom {
+    top: 20px !important;
+}
+
+.alert, .alert-warning {
+	margin-top: 20px !important;
+}
+
+#wrap {
+    padding-top: 19px !important;
+}
+
+#incompatible-browser-banner-top {
+    border:0;
+    display: table;
+    font-size: 15px;
+    height: 10px;
+    left:0;
+    position:fixed;
+    right:0;
+    text-align: center;
+    top:0;
+    margin:0;
+    width: 100%;
+    z-index: 1031;
+}
+
+.incompatible-browser-banner-text {
+    display: table-cell;
+    vertical-align: middle;
+    color: white;
+    background-color: red;
+}

--- a/exchange/static/css/multiple_banner_overrides.css
+++ b/exchange/static/css/multiple_banner_overrides.css
@@ -1,0 +1,33 @@
+.navbar-fixed-top, .navbar-fixed-bottom {
+    top: 40px !important;
+}
+
+.alert, .alert-warning {
+	margin-top: 40px !important;
+}
+
+#wrap {
+    padding-top: 19px !important;
+}
+
+#incompatible-browser-banner-top {
+    border:0;
+    display: table;
+    font-size: 15px;
+    height: 10px;
+    left:0;
+    position:fixed;
+    right:0;
+    text-align: center;
+    top:20px;
+    margin:0;
+    width: 100%;
+    z-index: 1031;
+}
+
+.incompatible-browser-banner-text {
+    display: table-cell;
+    vertical-align: middle;
+    color: white;
+    background-color: red;
+}

--- a/exchange/themes/templates/site_base.html
+++ b/exchange/themes/templates/site_base.html
@@ -59,13 +59,70 @@
             color: #FF8F4C;
         }
     {% endif %}
+    #incompatible-browser-banner-top {
+        border:0;
+        display: table;
+        font-size: 15px;
+        height: 10px;
+        left:0;
+        position:fixed;
+        right:0;
+        text-align: center;
+        top:0;
+        margin:0;
+        width: 100%;
+        z-index: 1031;
+    }
+
+    .incompatible-browser-banner-text {
+        display: table-cell;
+        vertical-align: middle;
+        color: white;
+        background-color: red;
+    }
   </style>
 {% endblock %}
 
 {% block header %}
+    <span id="incompatible-browser-banner-top">
+      <p class="incompatible-browser-banner-text"><b>Internet Explorer is not compatible with all features in Exchange. Please use Chrome or Firefox.</b></p>
+    </span>
     {% if classification_banner_enabled %}
-        <link href="{% static "css/django_classification_banner_overrides.css"%}" rel="stylesheet"/>
+        <script type="text/javascript">
+            if((navigator.userAgent.indexOf("MSIE") != -1 ) || (!!document.documentMode == true )) //IF IE > 10
+            {
+              // load our multiple_banner CSS file in the case of both banners being present
+              var multiple_banner_css = document.createElement('link');
+              multiple_banner_css.href='{% static "css/multiple_banner_overrides.css"%}';
+              multiple_banner_css.rel='stylesheet';
+              document.getElementsByTagName('head')[0].appendChild(multiple_banner_css);
+            } else {
+              // hide the banner if the browser is supported
+              var element = document.getElementById('incompatible-browser-banner-top');
+              element.style.display = 'none';
+              // Only load the django-classification-banner CSS if not in IE
+              var classification_banner_css = document.createElement('link');
+              classification_banner_css.href='{% static "css/django_classification_banner_overrides.css"%}';
+              classification_banner_css.rel='stylesheet';
+              document.getElementsByTagName('head')[0].appendChild(classification_banner_css);
+            }
+        </script>
         {% classification_banner %}
+    {% else %}
+        <script type="text/javascript">
+            if((navigator.userAgent.indexOf("MSIE") != -1 ) || (!!document.documentMode == true )) //IF IE > 10
+            {
+              // load our incompatible_browser CSS file if page loads in IE without classification banner
+              var incompatible_browser_css = document.createElement('link');
+              incompatible_browser_css.href='{% static "css/incompatible_browser_banner_overrides.css"%}';
+              incompatible_browser_css.rel='stylesheet';
+              document.getElementsByTagName('head')[0].appendChild(incompatible_browser_css);
+            } else {
+              // hide the banner if the browser is supported
+              var element = document.getElementById('incompatible-browser-banner-top');
+              element.style.display = 'none';
+            }
+        </script>
     {% endif %}
     {{ block.super }}
 {% endblock %}


### PR DESCRIPTION
…r Chrome

## JIRA Ticket
N/A - in GVS board

## Description
Adds a banner which appears if Exchange is loaded in Internet Explorer informing the user of browser incompatibility and suggesting use of Firefox or Chrome.

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
Open the Exchange localhost in Internet Explorer. You should see a red banner indicating that the browser is incompatible. This should appear if the classification banner is enabled, too.

Testing in Internet Explorer would be greatly appreciated, as I cannot on my system.

Screenshot of expected results:
![screenshot from 2018-10-22 10-19-54](https://user-images.githubusercontent.com/8084860/47307521-0fd9ec80-d5e4-11e8-9162-da8b04c4b484.png)


## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa 
