### PR TITLE
Cast bbox to list to prevent tuple error

### DIFF
--- a/exchange/views.py
+++ b/exchange/views.py
@@ -547,6 +547,7 @@ def new_map_config(request):
                 if bbox is None:
                     bbox = list(layer_bbox[0:4])
                 else:
+                    bbox = list(bbox)
                     bbox[0] = min(bbox[0], layer_bbox[0])
                     bbox[1] = max(bbox[1], layer_bbox[1])
                     bbox[2] = min(bbox[2], layer_bbox[2])


### PR DESCRIPTION
## JIRA Ticket
N/A

## Description
**NOTE:**
Requires: https://github.com/boundlessgeo/geonode/pull/265
When the GeoNode PR has been merged, GeoNode will need to be bumped in the vendor/submodules.

This PR comes from noticing a regression with the workspace functionality where opening multiple **WMS Service Layers** results in an error with the `bbox` being a `tuple` instead of a `list`. Casting it to a `list` fixes this error. For some reason the GeoNode function also gets called, so at the moment I've applied the fix to the same view in GeoNode.

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
1. Register the mapproxy remote service in Exchange, `http://mapproxy.boundless.test:8088/service`. Or any **WMS Service** with more than one resource will work fine.
2. Import all resources
3. Go the layers search page
4. Add multiple layers to the workspace
5. Attempt to open them in map viewer

Before the Exchange fix, you will see:
![screenshot from 2018-10-28 21-51-23](https://user-images.githubusercontent.com/8084860/47630055-f4974180-dafb-11e8-97a0-b4fa1d78933e.png)

Before the GeoNode fix, you will see (Exchange banner reappears as Exchange is fixed, but apparently MapLoom still calls the GeoNode view):
![screenshot from 2018-10-28 21-51-50](https://user-images.githubusercontent.com/8084860/47630062-f9f48c00-dafb-11e8-93d4-1ecfca8aa1af.png)

With both fixes present, MapLoom should load the layers normally again.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa