### PR TITLE
Pin regex version as latest causes errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ Django==1.8.18
 six==1.10.0
 cryptography==2.3
 urllib3==1.23
+regex==2018.11.03
 
 # For pki app
 # should be with [secure] for pyOpenSSL, cryptography, etc. for modern SSL


### PR DESCRIPTION
## JIRA Ticket
N/A

## Description
The `awesome-slugify` library has been pulling the latest `regex` version, which has now caused errors in our system as of `2018.11.06`. Pinning it to the previous version, `2018.11.03`, rectifies these errors. We should be pinning libraries for stability anyway, and although we have pinned `awesome-slugify`, that library has `regex` as a dependency and pulls latest, so we need to pin `regex` ourselves.

The error is seen here: https://gist.github.com/travislbrundage/785c696d7314a436eaf8e08c007189f5

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
_Add detailed steps for testing/review team to verify._

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa