### PR TITLE
Gvsd 7703

### DIFF
--- a/exchange/core/migrations/0013_exchangelayer.py
+++ b/exchange/core/migrations/0013_exchangelayer.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('layers', '0031_constraint'),
+        ('remoteservices', '0001_initial'),
+        ('core', '0012_adds_content_creator_group'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ExchangeLayer',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('exchange_service', models.ForeignKey(blank=True, to='remoteservices.ExchangeService', null=True)),
+                ('geonode_layer', models.OneToOneField(to='layers.Layer')),
+            ],
+        ),
+    ]

--- a/exchange/core/migrations/0014_adds_exchange_layer.py
+++ b/exchange/core/migrations/0014_adds_exchange_layer.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0013_exchangelayer"),
+        ('remoteservices', '0001_initial'),
+    ]
+
+    def create_exchange_layer(apps, schema_editor):
+        GeoNodeLayer = apps.get_model("layers", "Layer")
+        ExchangeLayer = apps.get_model("core", "exchangelayer")
+        ExchangeService = apps.get_model("remoteservices", "exchangeservice")
+        for layer in GeoNodeLayer.objects.all():
+            if layer.service is not None:
+                exchange_layer = ExchangeLayer(geonode_layer=layer)
+                exchange_layer.exchange_service = ExchangeService.objects.get(
+                    geonode_service=layer.service)
+                exchange_layer.save()
+
+    operations = [
+        migrations.RunPython(create_exchange_layer),
+    ]

--- a/exchange/core/models.py
+++ b/exchange/core/models.py
@@ -34,6 +34,8 @@ from geonode.base.enumerations import UPDATE_FREQUENCIES
 from django.conf import settings
 from django.db.models.signals import post_save
 from django.contrib.auth.models import Group
+from geonode.layers.models import Layer
+from exchange.remoteservices.models import ExchangeService
 
 
 class ThumbnailImage(SingletonModel):
@@ -222,3 +224,9 @@ def add_default_permissions(sender, **kwargs):
 
 
 post_save.connect(add_default_permissions, sender=settings.AUTH_USER_MODEL)
+
+
+class ExchangeLayer(models.Model):
+    geonode_layer = models.OneToOneField(Layer)
+    exchange_service = models.ForeignKey(ExchangeService,
+                                         null=True, blank=True)

--- a/exchange/remoteservices/admin.py
+++ b/exchange/remoteservices/admin.py
@@ -33,9 +33,8 @@ class ExchangeServiceAdminForm(ResourceBaseAdminForm):
 
 
 class ExchangeServiceAdmin(admin.ModelAdmin):
-    list_display = ('id', 'name', 'type', 'method')
-    list_display_links = ('id', 'name', )
-    list_filter = ('type', 'method')
+    list_display = ('id',)
+    list_display_links = ('id', )
     form = ExchangeServiceAdminForm
 
 

--- a/exchange/remoteservices/admin.py
+++ b/exchange/remoteservices/admin.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2018 Boundless Spatial
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from django.contrib import admin
+
+from geonode.base.admin import ResourceBaseAdminForm
+
+from . import models
+
+
+class ExchangeServiceAdminForm(ResourceBaseAdminForm):
+
+    class Meta:
+        model = models.ExchangeService
+        fields = '__all__'
+
+
+class ExchangeServiceAdmin(admin.ModelAdmin):
+    list_display = ('id', 'name', 'type', 'method')
+    list_display_links = ('id', 'name', )
+    list_filter = ('type', 'method')
+    form = ExchangeServiceAdminForm
+
+
+admin.site.register(models.ExchangeService, ExchangeServiceAdmin)

--- a/exchange/remoteservices/admin.py
+++ b/exchange/remoteservices/admin.py
@@ -33,8 +33,8 @@ class ExchangeServiceAdminForm(ResourceBaseAdminForm):
 
 
 class ExchangeServiceAdmin(admin.ModelAdmin):
-    list_display = ('id',)
-    list_display_links = ('id', )
+    list_display = ('id', 'geonode_service')
+    list_display_links = ('id', 'geonode_service')
     form = ExchangeServiceAdminForm
 
 

--- a/exchange/remoteservices/forms.py
+++ b/exchange/remoteservices/forms.py
@@ -18,11 +18,14 @@
 #
 #########################################################################
 
-from geonode.services.forms import CreateServiceForm
+from geonode.services.forms import CreateServiceForm, ServiceForm
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 from django.conf import settings
+from django import forms
 from geonode.services import enumerations
+from geonode.base.models import License
+from exchange.remoteservices.models import ExchangeService
 from exchange.remoteservices.serviceprocessors.handler \
     import get_service_handler
 try:
@@ -93,3 +96,95 @@ class ExchangeCreateServiceForm(CreateServiceForm):
                     )
             self.cleaned_data["service_handler"] = service_handler
             self.cleaned_data["type"] = service_handler.service_type
+
+
+# TODO: What is a better name for this?
+# Needs to be differentiated from form which applies to ExchangeService model
+class ServiceFormOverride(ServiceForm):
+    license = forms.ModelChoiceField(
+        label=_('License'),
+        queryset=License.objects.filter(),
+        required=False)
+    abstract = forms.CharField(
+        label=_("Abstract"),
+        widget=forms.Textarea(
+            attrs={
+                'cols': 60
+            }
+        ),
+        required=False
+    )
+    fees = forms.CharField(label=_('Fees'), max_length=1000,
+                           widget=forms.TextInput(
+                               attrs={
+                                   'size': '60',
+                                   'class': 'inputText'
+                               }), required=False)
+
+
+class ExchangeServiceForm(forms.ModelForm):
+    poc_name = forms.CharField(
+        label=_('Point of Contact'),
+        max_length=255,
+        widget=forms.TextInput(
+            attrs={
+                'size': '60',
+                'class': 'inputText'
+            }
+        ),
+        required=False
+    )
+    poc_position = forms.CharField(
+        label=_('PoC Position'),
+        max_length=255,
+        widget=forms.TextInput(
+            attrs={
+                'size': '60',
+                'class': 'inputText'
+            }
+        ),
+        required=False
+    )
+    poc_email = forms.CharField(
+        label=_('PoC Email'),
+        max_length=255,
+        widget=forms.TextInput(
+            attrs={
+                'size': '60',
+                'class': 'inputText'
+            }
+        ),
+        required=False
+    )
+    poc_phone = forms.CharField(
+        label=_('PoC Phone'),
+        max_length=255,
+        widget=forms.TextInput(
+            attrs={
+                'size': '60',
+                'class': 'inputText'
+            }
+        ),
+        required=False
+    )
+    poc_address = forms.CharField(
+        label=_('PoC Location/Address'),
+        max_length=255,
+        widget=forms.Textarea(
+            attrs={
+                'cols': 60
+            }
+        ),
+        required=False
+    )
+
+    class Meta:
+        model = ExchangeService
+        labels = {'description': _('Short Name')}
+        fields = (
+            'poc_name',
+            'poc_position',
+            'poc_email',
+            'poc_phone',
+            'poc_address',
+        )

--- a/exchange/remoteservices/migrations/0001_initial.py
+++ b/exchange/remoteservices/migrations/0001_initial.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('services', '0030_auto_20171212_0518'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ExchangeService',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('poc_name', models.CharField(max_length=255, null=True, blank=True)),
+                ('poc_position', models.CharField(max_length=255, null=True, blank=True)),
+                ('poc_email', models.CharField(max_length=255, null=True, blank=True)),
+                ('poc_phone', models.CharField(max_length=255, null=True, blank=True)),
+                ('poc_address', models.CharField(max_length=255, null=True, blank=True)),
+                ('geonode_service', models.OneToOneField(to='services.Service')),
+            ],
+        ),
+    ]

--- a/exchange/remoteservices/migrations/0002_adds_exchange_service.py
+++ b/exchange/remoteservices/migrations/0002_adds_exchange_service.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("remoteservices", "0001_initial")
+    ]
+
+    def create_exchange_service(apps, schema_editor):
+        RemoteService = apps.get_model("services", "service")
+        ExchangeService = apps.get_model("remoteservices", "exchangeservice")
+        for service in RemoteService.objects.all():
+            exchange_service = ExchangeService(geonode_service=service)
+            exchange_service.save()
+
+    operations = [
+        migrations.RunPython(create_exchange_service),
+    ]

--- a/exchange/remoteservices/models.py
+++ b/exchange/remoteservices/models.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2018 Boundless Spatial
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from django.db import models
+from geonode.services.models import Service
+from django.db.models import signals
+
+
+class ExchangeService(models.Model):
+    geonode_service = models.OneToOneField(Service)
+    poc_name = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True
+    )
+    poc_position = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True
+    )
+    poc_email = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True
+    )
+    poc_phone = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True
+    )
+    poc_address = models.CharField(
+        max_length=255,
+        null=True,
+        blank=True
+    )
+
+
+def exchange_service_post_save(instance, sender, **kwargs):
+    # Get all ExchangeLayers associated with this ExchangeService and
+    # update their license to correspond to the Service license
+    for layer in instance.exchangelayer_set.all():
+        layer.geonode_layer.license = instance.geonode_service.license
+        layer.save()
+
+
+signals.post_save.connect(exchange_service_post_save, sender=ExchangeService)

--- a/exchange/remoteservices/models.py
+++ b/exchange/remoteservices/models.py
@@ -57,7 +57,7 @@ def exchange_service_post_save(instance, sender, **kwargs):
     # update their license to correspond to the Service license
     for layer in instance.exchangelayer_set.all():
         layer.geonode_layer.license = instance.geonode_service.license
-        layer.save()
+        layer.geonode_layer.save()
 
 
 signals.post_save.connect(exchange_service_post_save, sender=ExchangeService)

--- a/exchange/remoteservices/templates/services/service_edit.html
+++ b/exchange/remoteservices/templates/services/service_edit.html
@@ -17,6 +17,7 @@
 <form method="POST" id="service_edit_form">
   {% csrf_token %}
   {{ service_form|as_bootstrap }}
+  {{ exchange_service_form|as_bootstrap }}
   <div class="grid-spacer">
     <p><input type="submit" class="btn btn-primary" value="{% trans "Save" %}"/></p>
   </div>

--- a/exchange/templates/base/_resourcebase_info_panel.html
+++ b/exchange/templates/base/_resourcebase_info_panel.html
@@ -85,9 +85,39 @@
     <dd><a itemprop="author" href="{{ resource.owner.get_absolute_url }}">{{ resource.owner.username }}</a></dd>
     {% endif %}
 
-    {% if resource.poc.user %}
+    {% if resource.service.classification %}
+    <dt>{% trans "Classification" %}</dt>
+    <dd>{{ resource.service.classification }}</dd>
+    {% endif %}
+
+    {% if resource.service.caveat %}
+    <dt>{% trans "Caveat" %}</dt>
+    <dd>{{ resource.service.caveat }}</dd>
+    {% endif %}
+
+    {% if resource.exchangelayer.exchange_service.poc_name %}
     <dt>{% trans "Point of Contact" %}</dt>
-    <dd><a href="{{ resource.poc.user.get_absolute_url }}">{{ resource.poc.user.username }}</a></dd>
+    <dd>{{ resource.exchangelayer.exchange_service.poc_name }}</dd>
+    {% endif %}
+
+    {% if resource.exchangelayer.exchange_service.poc_position %}
+    <dt>{% trans "PoC Position" %}</dt>
+    <dd>{{ resource.exchangelayer.exchange_service.poc_position }}</dd>
+    {% endif %}
+
+    {% if resource.exchangelayer.exchange_service.poc_email %}
+    <dt>{% trans "PoC Email" %}</dt>
+    <dd>{{ resource.exchangelayer.exchange_service.poc_email }}</dd>
+    {% endif %}
+
+    {% if resource.exchangelayer.exchange_service.poc_phone %}
+    <dt>{% trans "PoC Phone" %}</dt>
+    <dd>{{ resource.exchangelayer.exchange_service.poc_phone }}</dd>
+    {% endif %}
+
+    {% if resource.exchangelayer.exchange_service.poc_address %}
+    <dt>{% trans "PoC Address" %}</dt>
+    <dd>{{ resource.exchangelayer.exchange_service.poc_address }}</dd>
     {% endif %}
   </dl>
 


### PR DESCRIPTION
## JIRA Ticket
N/A

## Description
This PR is intended to synchronize our GVS changes into Exchange master, which includes additional metadata fields for `poc_name`, `poc_position`, `poc_email`, `poc_phone`, and `poc_address`. These changes initially represented a change in the `Service` model. Thus, we have run into a contention with Exchange, since we want to keep our updates within our Exchange repo, not modify GeoNode source directly, unless it is appropriate to do so. In this case, it is added functionality, and not appropriate for GeoNode community contribution.

In particular, this change highlights an important problem: How do we reasonably make updates to GeoNode that involve model changes? It's not uncommon we need model changes, and it can be difficult to work around direct changes to the GeoNode model. Furthermore, when we don't directly update the GeoNode model, it has the potential to get quite confusing architecturally, as it does in this case.

**NOTE**: This change coincides with a geonode-elasticsearch PR to provide additional faceting on new fields. https://github.com/boundlessgeo/geonode-elasticsearch/pull/76

# Substantive Change
There should be three visible changes with the inclusion of this PR.
First, we have updated the Service metadata with the new poc fields which should be shown in the service metadata form.

Second, the following metadata fields should be captured on the layer detail page, if they are available: `classification`, `caveat`, `poc_name`, `poc_position`, `poc_email`, `poc_phone`, and `poc_address`.

Third, there is an update to `geonode-elasticsearch` to facet on the following fields: `classification`, `caveat`, `license`, `provenance`, and `poc_name`.
They should appear as filters on the layer search page as a result.

# Technical Change
I've created a diagram to try to better visualize and explain what's going on with this change technically:
![gvsd-7703_diagram](https://user-images.githubusercontent.com/8084860/48461673-a46ddf80-e789-11e8-828a-aeb93e7f617d.png)


In order to include our metadata changes and reflect them on the layer detail page and search faceting, it’s required that we create two new models to reflect what otherwise would constitute GeoNode model changes (to `Service` and `Layer` directly).

The new metadata fields for services, `poc_name`, `poc_position`, `poc_email`, `poc_phone`, and `poc_address`, are captured in the `ExchangeService` model and given a 1 to 1 relationship to GeoNode’s `Service` model. Additionally, forms and views for the metadata have been updated to get the user’s input. We’ve also made some alterations to what fields are required, and included a CSS change to show the user what fields are required.

Next, to display the fields on the layer detail page and facet in search, an `ExchangeLayer` model connects the `ExchangeService` model with GeoNode’s Layer model, connecting Layer to these fields with one degree of separation. `Layer` -> `ExchangeLayer` -> `ExchangeService.poc_field`.

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
_Add detailed steps for testing/review team to verify._

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa