### PR TITLE
Add a settings variable to determine default user group perms

### DIFF
--- a/exchange/core/migrations/0012_adds_content_creator_group.py
+++ b/exchange/core/migrations/0012_adds_content_creator_group.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
+from django.conf import settings
 
 
 class Migration(migrations.Migration):
@@ -66,13 +67,11 @@ class Migration(migrations.Migration):
                      profile.is_superuser is False and
                      profile.username != 'AnonymousUser']
 
-        # Adding the content_creator and service_manager groups
-        # to all users by default
-        content_creator = AuthGroup.objects.get(name='content_creator')
-        service_manager = AuthGroup.objects.get(name='service_manager')
+        # Adding the default auth groups to all users
         for user in all_users:
-            user.groups.add(content_creator)
-            user.groups.add(service_manager)
+            for group_name in settings.DEFAULT_USER_AUTH_GROUPS:
+                auth_group = AuthGroup.objects.get(name=group_name)
+                user.groups.add(auth_group)
 
     operations = [
         migrations.RunPython(create_group),

--- a/exchange/core/models.py
+++ b/exchange/core/models.py
@@ -215,10 +215,9 @@ class CSWRecordReference(models.Model):
 def add_default_permissions(sender, **kwargs):
     user = kwargs['instance']
     if kwargs['created']:
-        content_creator = Group.objects.get(name='content_creator')
-        service_manager = Group.objects.get(name='service_manager')
-        user.groups.add(content_creator)
-        user.groups.add(service_manager)
+        for group_name in settings.DEFAULT_USER_AUTH_GROUPS:
+            auth_group = Group.objects.get(name=group_name)
+            user.groups.add(auth_group)
 
 
 post_save.connect(add_default_permissions, sender=settings.AUTH_USER_MODEL)

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -615,6 +615,9 @@ DEFAULT_ANONYMOUS_VIEW_PERMISSION_REMOTE = str2bool(
 DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION_REMOTE = str2bool(
     os.getenv('DEFAULT_ANONYMOUS_DOWNLOAD_PERMISSION_REMOTE', 'True'))
 
+# List of auth groups to add new users to by default
+DEFAULT_USER_AUTH_GROUPS = ['content_creator', 'service_manager']
+
 ENABLE_SOCIAL_LOGIN = str2bool(os.getenv('ENABLE_SOCIAL_LOGIN', 'False'))
 
 # Should always be set to true if we're behind a proxy


### PR DESCRIPTION
## JIRA Ticket
[BEX-1007]

## Description
A follow up to: https://github.com/boundlessgeo/exchange/pull/43

Adds a settings variable, `DEFAULT_USER_AUTH_GROUPS`, which determines what permissions to give new Exchange users by default. Also updates the migration, although it was already present prior to this.

Use the precise name of any auth group and add it to the list, and newly created users will gain the permissions of that group. By default, users are being added to the `content_creator` and `service_manager` groups. If the list is empty, users will only be able to view, and not add any content.

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
_Add detailed steps for testing/review team to verify._

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa