### PR TITLE
Bump requests library to 2.20.1 for bugfix with auth header stripping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ regex==2018.11.03
 # should be with [secure] for pyOpenSSL, cryptography, etc. for modern SSL
 # urllib3[secure]==1.22
 # minimum of requests 2.12 needed, though not sure if it is urllib3-bug-free
-requests==2.20.0
+requests==2.20.1
 # more robust SSL in urllib3 with pyOpenSSL
 # pyOpenSSL==17.5.0
 # PKI component validations and db field encryption


### PR DESCRIPTION
## JIRA Ticket
N/A

## Description
Fixes the latest CI errors we're seeing with PKI test failures due to a bug in `requests==2.20.0`.
CI errors: https://ciapi.boundlessgeo.io/blue/organizations/jenkins/Exchange/detail/PR-57/1/pipeline
2.20.1 release notes: https://github.com/requests/requests/commit/6cfbe1aedd56f8c2f9ff8b968efe65b22669795b#diff-88dc7475eedf918122374be6d7c2c151R11

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
CI should pass on this PR.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa