### PR TITLE
Fixing incorrect loading of bbox for remote services

### DIFF
--- a/exchange/views.py
+++ b/exchange/views.py
@@ -271,8 +271,9 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
         config["styles"] = layer.default_style.name
 
     if layer.storeType == "remoteStore":
+        target_srid = 3857 if config["srs"] == 'EPSG:900913' else config["srs"]
         reprojected_bbox = bbox_to_projection(bbox, source_srid=layer.srid,
-                                              target_srid=3857)
+                                              target_srid=target_srid)
         bbox = reprojected_bbox[:4]
         config['bbox'] = [float(coord) for coord in bbox]
         service = layer.service
@@ -576,10 +577,14 @@ def new_map_config(request):
                         ogc_server_settings.PUBLIC_LOCATION).netloc
                     service_url = urlsplit(service.base_url).netloc
 
+                    if config["srs"] == 'EPSG:900913':
+                        target_srid = 3857
+                    else:
+                        target_srid = config["srs"]
                     reprojected_bbox = bbox_to_projection(
                         bbox,
                         source_srid=layer.srid,
-                        target_srid=3857
+                        target_srid=target_srid
                     )
                     bbox = reprojected_bbox[:4]
                     config['bbox'] = [float(coord) for coord in bbox]


### PR DESCRIPTION
## JIRA Ticket
GVSD-8509

## Description
Fixes the geonode-client's bbox to take into account the settings for our target srid.
NOTE: Coincides with the following geonode PR to correct mishandling of bbox order - https://github.com/boundlessgeo/geonode/pull/267

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
On the layers detail page, the map should zoom to a sensible extent by default in all cases.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa