### PR TITLE
Enable use of GEOGIG_ENABLED to affect osgeo_importer

### DIFF
--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -75,6 +75,7 @@ def resource_variables(request):
         PROXY_BASEMAP=getattr(settings, 'PROXY_BASEMAP', False),
         GOOGLE_ANALYTICS_ID=getattr(settings, 'GOOGLE_ANALYTICS_ID', False),
         MAPLOOM_ENABLED=getattr(settings, 'MAPLOOM_ENABLED', True),
+        GEOGIG_ENABLED=getattr(settings, 'GEOGIG_ENABLED', False),
     )
 
     return defaults

--- a/exchange/settings/default.py
+++ b/exchange/settings/default.py
@@ -275,6 +275,7 @@ GEOGIG_DATASTORE_DIR = os.getenv(
 PG_DATASTORE = os.getenv('PG_DATASTORE', 'exchange_imports')
 PG_GEOGIG = str2bool(os.getenv('PG_GEOGIG', 'True'))
 
+GEOGIG_ENABLED = str2bool(os.getenv('GEOGIG_ENABLED', 'False'))
 OGC_SERVER = {
     'default': {
         'BACKEND': 'geonode.geoserver',
@@ -287,7 +288,7 @@ OGC_SERVER = {
         'MAPFISH_PRINT_ENABLED': True,
         'PRINT_NG_ENABLED': True,
         'GEONODE_SECURITY_ENABLED': True,
-        'GEOGIG_ENABLED': True,
+        'GEOGIG_ENABLED': GEOGIG_ENABLED,
         'WMST_ENABLED': False,
         'BACKEND_WRITE_ENABLED': True,
         'WPS_ENABLED': True,

--- a/exchange/static/osgeo_importer/importer.js
+++ b/exchange/static/osgeo_importer/importer.js
@@ -328,7 +328,7 @@
 
 
             $scope.geogigEnabled = function() {
-                if ($scope.layer == null || $scope.layer.layer_type == 'raster') {
+                if ( !geogig_enabled || $scope.layer == null || $scope.layer.layer_type == 'raster') {
                     return false;
                 } else {
                     return true;

--- a/exchange/templates/osgeo_importer/uploads-list.html
+++ b/exchange/templates/osgeo_importer/uploads-list.html
@@ -4,6 +4,9 @@
 {% block extra_script %}
     {% include 'osgeo_importer/_importer_scripts.html' %}
     {% include 'osgeo_importer/_importer_styles.html' %}
+    <script>
+      var geogig_enabled = {{ GEOGIG_ENABLED|yesno:"true,false" }};
+    </script>
     {{ block.super }}
 {% endblock %}
 


### PR DESCRIPTION
Previously osgeo_importer wizard didn't check
the GEOGIG_ENABLED variable to determine if the
version control tab should be included or not.
This is the more correct and desired behavior.

