### PR TITLE
Use the Service extent rather than layer extent since Service extent …

### DIFF
--- a/exchange/views.py
+++ b/exchange/views.py
@@ -44,6 +44,8 @@ from geonode.contrib.createlayer.utils import create_layer
 from geonode.contrib.createlayer.forms import NewLayerForm
 from django.utils.translation import ugettext as _
 from geonode.people.models import Profile
+from exchange.remoteservices.serviceprocessors.handler \
+    import get_service_handler
 
 if 'geonode.geoserver' in settings.INSTALLED_APPS:
     from geonode.geoserver.helpers import ogc_server_settings
@@ -275,8 +277,49 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
         config["styles"] = layer.default_style.name
 
     if layer.storeType == "remoteStore":
-        reprojected_bbox = bbox_to_projection(bbox, source_srid=layer.srid,
-                                              target_srid=3857)
+        source_srid = None
+        # Only grab the service proj/bbox if it is valid
+        if None not in layer.service.bbox[0:4]:
+            bbox = [float(coord) for coord in list(layer.service.bbox[0:4])]
+            source_srid = layer.service.srid
+        # Otherwise try the service directly
+        # This is needed since previous services registered
+        # did not store the bbox/srid in the model
+        else:
+            try:
+                service_handler = get_service_handler(
+                    base_url=layer.service.base_url,
+                    service_type=layer.service.type)
+                if getattr(service_handler.parsed_service, 'initialExtent',
+                           None):
+                    bbox[0] = service_handler.parsed_service.initialExtent[
+                        'xmin']
+                    bbox[1] = service_handler.parsed_service.initialExtent[
+                        'ymin']
+                    bbox[2] = service_handler.parsed_service.initialExtent[
+                        'xmax']
+                    bbox[3] = service_handler.parsed_service.initialExtent[
+                        'ymax']
+                else:
+                    logger.info('Could not retrieve extent from service: {0}'
+                                .format(layer.service))
+                if getattr(service_handler.parsed_service, 'spatialReference',
+                           None):
+                    source_srid = \
+                        service_handler.parsed_service.spatialReference[
+                            'latestWkid']
+                else:
+                    logger.info('Could not retrieve srid from service: {0}'
+                                .format(layer.service))
+            except Exception as e:
+                logger.info('Failed to access service endpoint: {0}'
+                            .format(layer.service.base_url))
+                logger.info('Caught error: {0}'.format(e))
+        if source_srid is None:
+            source_srid = layer.srid
+        target_srid = 3857 if config["srs"] == 'EPSG:900913' else config["srs"]
+        reprojected_bbox = bbox_to_projection(bbox, source_srid=source_srid,
+                                              target_srid=target_srid)
         bbox = reprojected_bbox[:4]
         config['bbox'] = [float(coord) for coord in bbox]
         service = layer.service


### PR DESCRIPTION
…appears more accurate. Store in the Service model during registration.

## JIRA Ticket
[GVSD-8566]

## Description
Fixes extent on layer detail page.

Requires bug fix: https://github.com/boundlessgeo/geonode/pull/269

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
All services should now have the correct default extent in the React viewer.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start 
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa