### PR TITLE
Add context processor for OAM_REMOTE_USER to be used by matomo code w…

### DIFF
--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -38,6 +38,10 @@ if settings.GEOQUERY_ENABLED:
 
 def resource_variables(request):
     """Global exchange values to pass to templates"""
+    OAM_REMOTE_USER = None
+    if settings.GEOQUERY_ENABLED:
+        if settings.GEOAXIS_HEADER in request.META:
+            OAM_REMOTE_USER = request.META[settings.GEOAXIS_HEADER]
     defaults = dict(
         VERSION=get_version(),
         MAP_CRS=getattr(settings, 'DEFAULT_MAP_CRS', None),
@@ -77,6 +81,7 @@ def resource_variables(request):
         MAPLOOM_ENABLED=getattr(settings, 'MAPLOOM_ENABLED', True),
         GEOGIG_ENABLED=getattr(settings, 'GEOGIG_ENABLED', False),
         INVITES_ENABLED=getattr(settings, 'INVITES_ENABLED', True),
+        OAM_REMOTE_USER=OAM_REMOTE_USER,
     )
 
     return defaults

--- a/exchange/themes/templates/tracking_footer.html
+++ b/exchange/themes/templates/tracking_footer.html
@@ -13,5 +13,8 @@
 {% endif %}
 
 {% if theme.custom_analytics %}
+<script>
+  var oam_remote = '{{ OAM_REMOTE_USER }}';
+</script>
   {{ theme.custom_analytics | safe }}
 {% endif %}

--- a/exchange/urls.py
+++ b/exchange/urls.py
@@ -81,7 +81,7 @@ else:
 
 if not settings.INVITES_ENABLED:
     urlpatterns += (
-        url(r'^account/invite_user/$', views.invites_http_404_view, 
+        url(r'^account/invite_user/$', views.invites_http_404_view,
             name='invite_404'),
     )
 

--- a/exchange/views.py
+++ b/exchange/views.py
@@ -118,8 +118,10 @@ def documentation_page(request):
 def maploom_http_404_view(request):
     raise Http404('MapLoom has been disabled')
 
+
 def invites_http_404_view(request):
     raise Http404('Invites have been disabled')
+
 
 def get_pip_version(project):
     version = [


### PR DESCRIPTION
…ithin custom analytics theming

## JIRA Ticket
GVSD-9170

## Description
Along with the JavaScript loader in matomo_loader.js, this code will enable user id tracking on the GVS system by passing the OAM_REMOTE_USER header into the script context.

There is a small concern with exposing this header in the context, however, this only gets exposed if you are authenticated in the first place. Furthermore, it should not be possible to spoof, because the authentication would fail. If somehow you could spoof it, the worst that can happen is the user's id is exposed, which should be relatively meaningless as it's not an auth token. Worst case scenario, the tracking metrics would get thrown off.

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
Need to ask GVS upon 9.2 deployment if the tracking metrics are behaving as expected now.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa