### PR TITLE
Enable use of GEOGIG_ENABLED to affect osgeo_importer

### DIFF
--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -74,6 +74,7 @@ def resource_variables(request):
         ES_SEARCH=getattr(settings, 'ES_SEARCH', False),
         PROXY_BASEMAP=getattr(settings, 'PROXY_BASEMAP', False),
         GOOGLE_ANALYTICS_ID=getattr(settings, 'GOOGLE_ANALYTICS_ID', False),
+        GEOGIG_ENABLED=getattr(settings, 'GEOGIG_ENABLED', False),
     )
 
     return defaults

--- a/exchange/static/osgeo_importer/importer.js
+++ b/exchange/static/osgeo_importer/importer.js
@@ -328,7 +328,7 @@
 
 
             $scope.geogigEnabled = function() {
-                if ($scope.layer == null || $scope.layer.layer_type == 'raster') {
+                if ( !geogig_enabled || $scope.layer == null || $scope.layer.layer_type == 'raster') {
                     return false;
                 } else {
                     return true;

--- a/exchange/templates/osgeo_importer/uploads-list.html
+++ b/exchange/templates/osgeo_importer/uploads-list.html
@@ -4,6 +4,9 @@
 {% block extra_script %}
     {% include 'osgeo_importer/_importer_scripts.html' %}
     {% include 'osgeo_importer/_importer_styles.html' %}
+    <script>
+      var geogig_enabled = {{ GEOGIG_ENABLED|yesno:"true,false" }};
+    </script>
     {{ block.super }}
 {% endblock %}
 


### PR DESCRIPTION
Previously osgeo_importer wizard didn't check
the GEOGIG_ENABLED variable to determine if the
version control tab should be included or not.
This is the more correct and desired behavior.

## JIRA Ticket
N/A

## Description
Allows us to set `GEOGIG_ENABLED` to toggle functionality on or off.

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
Set the env variable `GEOGIG_ENABLED` to `False` and importer should no longer prompt you for version control. Setting it to `True` brings the option back. Lacking the variable defaults to `False`.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa