### PR TITLE
geoquery patch

### DIFF
--- a/exchange/core/context_processors.py
+++ b/exchange/core/context_processors.py
@@ -25,13 +25,16 @@ from urlparse import urlparse
 
 logger = logging.getLogger(__name__)
 
-if settings.GEOQUERY_ENABLED:
-    if settings.GEOQUERY_URL is None:
+
+GEOQUERY_ENABLED = getattr(settings, 'GEOQUERY_ENABLED', False)
+GEOQUERY_URL = getattr(settings, 'GEOQUERY_URL', None)
+if GEOQUERY_ENABLED:
+    if GEOQUERY_URL is None:
         logger.warn('No search endpoint defined.')
         logger.warn(
             'GEOQUERY_ENABLED was set to True, but GEOQUERY_URL '
             'was not defined.')
-    elif urlparse(settings.GEOQUERY_URL).netloc is '':
+    elif urlparse(GEOQUERY_URL).netloc is '':
         logger.warn(
             'GEOQUERY_URL improperly defined or is not a valid URL.')
 


### PR DESCRIPTION
django will not start, because the context processor is expecting a setting from the settings file. Adjustment is now setting a default value if the value is not in the settings file.