### PR TITLE
Gvsd 10214

### DIFF
--- a/exchange/tests/geonode_elasticsearch_test.py
+++ b/exchange/tests/geonode_elasticsearch_test.py
@@ -187,17 +187,8 @@ class GeonodeElasticsearchTest(ExchangeTest):
                 },
                 "type": "text"
             },
-            "bbox_bottom": {
-                "type": "float"
-            },
-            "bbox_left": {
-                "type": "float"
-            },
-            "bbox_right": {
-                "type": "float"
-            },
-            "bbox_top": {
-                "type": "float"
+            "bbox": {
+                "type": "geo_shape"
             },
             "category": {
                 "fields": {
@@ -350,9 +341,6 @@ class GeonodeElasticsearchTest(ExchangeTest):
             "has_time": {
                 "type": "boolean"
             },
-            "bbox_top": {
-                "type": "float"
-            },
             "category__gn_description": {
                 "type": "text"
             },
@@ -375,11 +363,8 @@ class GeonodeElasticsearchTest(ExchangeTest):
             "srid": {
                 "type": "keyword"
             },
-            "bbox_bottom": {
-                "type": "float"
-            },
-            "bbox_right": {
-                "type": "float"
+            "bbox": {
+                "type": "geo_shape"
             },
             "keywords": {
                 "fields": {
@@ -489,9 +474,6 @@ class GeonodeElasticsearchTest(ExchangeTest):
             },
             "supplemental_information": {
                 "type": "text"
-            },
-            "bbox_left": {
-                "type": "float"
             },
             "temporal_extent_start": {
                 "type": "date"
@@ -633,17 +615,8 @@ class GeonodeElasticsearchTest(ExchangeTest):
                 },
                 "type": "text"
             },
-            "bbox_bottom": {
-                "type": "float"
-            },
-            "bbox_left": {
-                "type": "float"
-            },
-            "bbox_right": {
-                "type": "float"
-            },
-            "bbox_top": {
-                "type": "float"
+            "bbox": {
+                "type": "geo_shape"
             },
             "category": {
                 "fields": {


### PR DESCRIPTION
## JIRA Ticket
GVSD-10214

## Description
Adds bounding box as a `GeoShape` type to facilitate spatial filtering. Changes our bounding box filter to be an `intersects` rather than `contains`.

NOTE: You will need to run a `rebuild_index` after pulling the changes from `geonode-elasticsearch` to update your data to index the bounding box as a `GeoShape`. If you do not do this, the filtering will not work.

In `/api/base/search/`, the `extent` filter will now apply an `intersects`. You should also see a new field, `bbox`, for any `ResourceBase` data which has a `type` of `envelope` and a set of `coordinates` corresponding to its bounding box in the form of `[[minx, miny], [maxx, maxy]]`.

NOTE: Requires https://github.com/boundlessgeo/geonode-elasticsearch/pull/84

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
Using the attached [SoloAmericas.zip](https://github.com/boundlessgeo/exchange/files/3169678/SoloAmericas.zip) data, the following `extent` queries should return the layer:
```
/api/base/search/?limit=100&offset=0&type=layer&extent=-170,50,-160,80
/api/base/search/?limit=100&offset=0&type=layer&extent=-160,50,-40,80
/api/base/search/?limit=100&offset=0&type=layer&extent=-40,50,40,80
/api/base/search/?limit=100&offset=0&type=layer&extent=-170,0,-160,50
/api/base/search/?limit=100&offset=0&type=layer&extent=-160,0,-40,50
/api/base/search/?limit=100&offset=0&type=layer&extent=-40,0,40,50
/api/base/search/?limit=100&offset=0&type=layer&extent=-170,-80,-160,0
/api/base/search/?limit=100&offset=0&type=layer&extent=-160,-80,-40,0
/api/base/search/?limit=100&offset=0&type=layer&extent=-40,-80,40,0
/api/base/search/?limit=100&offset=0&type=layer&extent=-180,-80,30,80
```
The following `extent` query should not return `Solo_Americas` in its results:
```
/api/base/search/?limit=100&offset=0&type=layer&extent=0,100,10,110
```

It would also be good to test the filtering works for remote service layers as well.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa