### PR TITLE
Add missing migration

### DIFF
--- a/exchange/3pm/user_messages/0004_auto_20190515_0419.py
+++ b/exchange/3pm/user_messages/0004_auto_20190515_0419.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('user_messages', '0003_auto_20190419_1024'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='groupmemberthread',
+            name='group',
+        ),
+        migrations.RemoveField(
+            model_name='groupmemberthread',
+            name='thread',
+        ),
+        migrations.RemoveField(
+            model_name='groupmemberthread',
+            name='user',
+        ),
+        migrations.RemoveField(
+            model_name='thread',
+            name='group_users',
+        ),
+        migrations.RemoveField(
+            model_name='thread',
+            name='single_users',
+        ),
+        migrations.AddField(
+            model_name='thread',
+            name='users',
+            field=models.ManyToManyField(to=settings.AUTH_USER_MODEL,
+                                         verbose_name='Users',
+                                         through='user_messages.UserThread'),
+        ),
+        migrations.AlterField(
+            model_name='userthread',
+            name='deleted',
+            field=models.BooleanField(),
+        ),
+        migrations.AlterField(
+            model_name='userthread',
+            name='unread',
+            field=models.BooleanField(),
+        ),
+        migrations.DeleteModel(
+            name='GroupMemberThread',
+        ),
+    ]


### PR DESCRIPTION
## JIRA Ticket
N/A

## Description
A necessary migration was missing for autocomplete's updates. Adds this migration. Identical to the main `gvs-pki` PR: https://github.com/boundlessgeo/exchange/pull/94

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
`python manage.py makemigrations` should no longer ask for an additional migration.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa