### PR TITLE
Gvsd 9821

### DIFF
--- a/exchange/templates/documents/document_detail.html
+++ b/exchange/templates/documents/document_detail.html
@@ -257,12 +257,12 @@
     {% include "_permissions_form_js.html" %}
     <script type="text/javascript">
         $('#set_thumbnail').click(function(){
-          createDocumentThumbnail();
           $('#edit-document').modal('toggle');
+          createDocumentThumbnail();
         });
         $('#set_thumbnail_from_file').click(function() {
-          uploadThumbnail('thumbnail-file');
           $('#edit-document').modal('toggle');
+          uploadThumbnail('thumbnail-file');
         });
       </script>
 {% endblock extra_script %}

--- a/exchange/templates/documents/document_detail.html
+++ b/exchange/templates/documents/document_detail.html
@@ -226,6 +226,8 @@
 
       {% include "base/_resourcebase_contact_snippet.html" %}
 
+      {% include "thumbnail_feedback.html" %}
+
     </ul>
   </div>
 </div>

--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -610,6 +610,8 @@
     {% endif %}
 
     {% include "base/_resourcebase_contact_snippet.html" %}
+
+    {% include "thumbnail_feedback.html" %}
   </ul>
 
 

--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -677,6 +677,10 @@
       });
       $('#set_thumbnail_from_file').click(function() {
         $('#edit-layer').modal('toggle');
+        // TODO: Remove warning when MoW jquery incompatibilities are fixed
+        {% if preview == 'MOW' %}
+          console.log('WARNING: Modals do not load properly with MoW, but thumbnails still set');
+        {% endif %}
         uploadThumbnail('thumbnail-file');
       });
     </script>

--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -440,7 +440,9 @@
               <div class="col-sm-4">
                 <i class="fa fa-photo fa-3x"></i>
                 <h4>{% trans "Thumbnail" %}</h4>
-                <a class="btn btn-default btn-block btn-xs" href="#" id="set_thumbnail">{% trans "Set" %}</a>
+                {% if preview == 'react' %}
+                  <a class="btn btn-default btn-block btn-xs" href="#" id="set_thumbnail">{% trans "Set" %}</a>
+                {% endif %}
                 <a class="btn btn-default btn-block btn-xs" href="#" id="set_thumbnail_from_file">{% trans "Set from file" %}</a>
                 <input type="file" id="thumbnail-file" style="display:none"/>
               </div>

--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -27,11 +27,11 @@
   {% elif preview == 'MOW' %}
     {% include "layers/MOW_map.html" %}
   {% elif preview == 'react' %}
-    <script type="text/javascript" src="{{ STATIC_URL}}geonode/js/utils/thumbnail.js"></script>
     {% include 'geonode-client/layer_map.html' %}
   {% else %}
     {% include "layers/layer_leaflet_map.html" %}
   {% endif %}
+<script type="text/javascript" src="{{ STATIC_URL}}geonode/js/utils/thumbnail.js"></script>
 {{ block.super }}
 {% endblock %}
 

--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -672,12 +672,12 @@
         </script>
     <script type="text/javascript">
       $('#set_thumbnail').click(function(){
-        createMapThumbnail();
         $('#edit-layer').modal('toggle');
+        createMapThumbnail();
       });
       $('#set_thumbnail_from_file').click(function() {
-        uploadThumbnail('thumbnail-file');
         $('#edit-layer').modal('toggle');
+        uploadThumbnail('thumbnail-file');
       });
     </script>
     {% if GEONODE_SECURITY_ENABLED %}

--- a/exchange/templates/maps/map_detail.html
+++ b/exchange/templates/maps/map_detail.html
@@ -332,12 +332,12 @@
 <script type="text/javascript" src="{{ STATIC_URL}}geonode/js/utils/thumbnail.js"></script>
 <script type="text/javascript">
   $('#set_thumbnail').click(function(){
-    createMapThumbnail();
     $('#edit-map').modal('toggle');
+    createMapThumbnail();
   });
   $('#set_thumbnail_from_file').click(function() {
-    uploadThumbnail('thumbnail-file');
     $('#edit-map').modal('toggle');
+    uploadThumbnail('thumbnail-file');
   });
 </script>
  

--- a/exchange/templates/maps/map_detail.html
+++ b/exchange/templates/maps/map_detail.html
@@ -131,7 +131,9 @@
                   <div class="col-sm-3">
                     <i class="fa fa-photo fa-3x"></i>
                     <h4>{% trans "Thumbnail" %}</h4>
-                    <a class="btn btn-default btn-block btn-xs" href="#" id="set_thumbnail">{% trans "Set" %}</a>
+                    {% if preview == 'react' %}
+                      <a class="btn btn-default btn-block btn-xs" href="#" id="set_thumbnail">{% trans "Set" %}</a>
+                    {% endif %}
                     <a class="btn btn-default btn-block btn-xs" href="#" id="set_thumbnail_from_file">{% trans "Set from file" %}</a>
                     <input type="file" id="thumbnail-file" style="display:none"/>
                   </div>

--- a/exchange/templates/maps/map_detail.html
+++ b/exchange/templates/maps/map_detail.html
@@ -234,6 +234,8 @@
         {% endif %}
 
         {% include "base/_resourcebase_contact_snippet.html" %}
+
+        {% include "thumbnail_feedback.html" %}
     
       </ul>
       

--- a/exchange/templates/maps/map_detail.html
+++ b/exchange/templates/maps/map_detail.html
@@ -337,6 +337,10 @@
   });
   $('#set_thumbnail_from_file').click(function() {
     $('#edit-map').modal('toggle');
+    // TODO: Remove warning when MoW jquery incompatibilities are fixed
+    {% if preview == 'MOW' %}
+      console.log('WARNING: Modals do not load properly with MoW, but thumbnails still set');
+    {% endif %}
     uploadThumbnail('thumbnail-file');
   });
 </script>

--- a/exchange/themes/templates/thumbnail_feedback.html
+++ b/exchange/themes/templates/thumbnail_feedback.html
@@ -1,0 +1,16 @@
+<div class="modal fade" id="thumbnail_feedback" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">Title</h4>
+      </div>
+      <div class="modal-body">
+        ...
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">OK</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/exchange/thumbnails/static/geonode/js/utils/thumbnail.js
+++ b/exchange/thumbnails/static/geonode/js/utils/thumbnail.js
@@ -17,6 +17,8 @@ var refreshThumbnail = function() {
         thumb.attr('src', thumb.attr('src').split('?')[0] + '?.ck=' + time_str);
 }
 
+// TODO: This is designed to work with React viewer
+// Needs to be updated to work with MoW
 var createMapThumbnail = function() {
     var canvas = document.getElementsByTagName('canvas')[0];
 

--- a/exchange/thumbnails/static/geonode/js/utils/thumbnail.js
+++ b/exchange/thumbnails/static/geonode/js/utils/thumbnail.js
@@ -11,6 +11,33 @@ var getThumbnailPathFromUrl = function() {
     return '/thumbnails/' + path_info[0] + '/' + path_info[1];
 }
 
+// TODO: Update this to use js-cookie library instead of this mess
+function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+        var cookies = document.cookie.split(';');
+        for (var i = 0; i < cookies.length; i++) {
+            var cookie = cookies[i].trim();
+            // Does this cookie string begin with the name we want?
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+
+var getCsrfToken = function() {
+    // return Cookies.get('csrftoken');
+    return getCookie('csrftoken');
+}
+
+var csrfSafeMethod = function(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+
 var refreshThumbnail = function() {
         var thumb = $('#thumbnail');
         var time_str = (new Date()).getTime();
@@ -42,6 +69,13 @@ var createMapThumbnail = function() {
 
     var url = getThumbnailPathFromUrl();
 
+    $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+            if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+                xhr.setRequestHeader("X-CSRFToken", getCsrfToken());
+            }
+        }
+    });
     $.ajax({
         type: "POST",
         url: url,
@@ -57,6 +91,13 @@ var createMapThumbnail = function() {
 var createDocumentThumbnail = function() {
     var url = getThumbnailPathFromUrl();
 
+    $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+            if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+                xhr.setRequestHeader("X-CSRFToken", getCsrfToken());
+            }
+        }
+    });
     $.ajax({
         type: "POST",
         url: url,
@@ -81,6 +122,13 @@ var uploadThumbnail = function(inputId) {
     //  send it up to the server.
     //reader.onload = function(e) {
     var upload = function() {
+        $.ajaxSetup({
+            beforeSend: function(xhr, settings) {
+                if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+                    xhr.setRequestHeader("X-CSRFToken", getCsrfToken());
+                }
+            }
+        });
         $.ajax({
             type: "POST",
             url: url,

--- a/exchange/thumbnails/static/geonode/js/utils/thumbnail.js
+++ b/exchange/thumbnails/static/geonode/js/utils/thumbnail.js
@@ -82,7 +82,21 @@ var createMapThumbnail = function() {
         data: png_data,
         success: function(data, status, jqXHR) {
             refreshThumbnail();
-            return true;
+            var title = 'Success';
+            var body = 'Thumbnail was successfully set';
+            $("#thumbnail_feedback").find('.modal-title').text(title);
+            $("#thumbnail_feedback").find('.modal-body').text(body);
+            // TODO: Modals currently will conflict with MoW
+            $("#thumbnail_feedback").modal("show");
+        },
+        error: function(data, status, jqXHR) {
+            var title = 'Failure';
+            var body = 'Unable to set thumbnail: HTTP ' + data.status + ' error. ' + data.responseText;
+            console.log(body);
+            $("#thumbnail_feedback").find('.modal-title').text(title);
+            $("#thumbnail_feedback").find('.modal-body').text(body);
+            // TODO: Modals currently will conflict with MoW
+            $("#thumbnail_feedback").modal("show");
         }
     });
     return true;
@@ -104,7 +118,21 @@ var createDocumentThumbnail = function() {
         data: 'refresh',
         success: function(data, status, jqXHR) {
             refreshThumbnail();
-            return true;
+            var title = 'Success';
+            var body = 'Thumbnail was successfully set';
+            $("#thumbnail_feedback").find('.modal-title').text(title);
+            $("#thumbnail_feedback").find('.modal-body').text(body);
+            // TODO: Modals currently will conflict with MoW
+            $("#thumbnail_feedback").modal("show");
+        },
+        error: function(data, status, jqXHR) {
+            var title = 'Failure';
+            var body = 'Unable to set thumbnail: HTTP ' + data.status + ' error. ' + data.responseText;
+            console.log(body);
+            $("#thumbnail_feedback").find('.modal-title').text(title);
+            $("#thumbnail_feedback").find('.modal-body').text(body);
+            // TODO: Modals currently will conflict with MoW
+            $("#thumbnail_feedback").modal("show");
         }
     });
     return true;
@@ -136,6 +164,21 @@ var uploadThumbnail = function(inputId) {
             processData: false,
             success: function(data, status, jqXHR) {
                 refreshThumbnail();
+                var title = 'Success';
+                var body = 'Thumbnail was successfully set';
+                $("#thumbnail_feedback").find('.modal-title').text(title);
+                $("#thumbnail_feedback").find('.modal-body').text(body);
+                // TODO: Modals currently will conflict with MoW
+                $("#thumbnail_feedback").modal("show");
+            },
+            error: function(data, status, jqXHR) {
+                var title = 'Failure';
+                var body = 'Unable to set thumbnail: HTTP ' + data.status + ' error. ' + data.responseText;
+                console.log(body);
+                $("#thumbnail_feedback").find('.modal-title').text(title);
+                $("#thumbnail_feedback").find('.modal-body').text(body);
+                // TODO: Modals currently will conflict with MoW
+                $("#thumbnail_feedback").modal("show");
             }
         });
     }

--- a/exchange/thumbnails/tasks.py
+++ b/exchange/thumbnails/tasks.py
@@ -437,9 +437,8 @@ def get_thumbnails(instance):
                         layer.storeType == 'remoteStore' and
                         layer.service.type == 'REST'):
                     rest_layers.append(layer)
-                # TODO: Is this a bad case?
                 else:
-                    local_layers.append(layer)
+                    logger.debug('could not find layer %s', layer.name)
             except:
                 logger.debug('could not find layer %s', layer.name)
         logger.debug('LAYERS: %s      |||    WMS LAYERS: %s',
@@ -464,7 +463,6 @@ def get_thumbnails(instance):
                                                 bbox=bbox, format='image/jpeg')
                 if content:
                     return_images.append(content)
-        # TODO: Does combine_images work with REST layers?
         if len(rest_layers) > 0:
             for rest_layer in rest_layers:
                 thumbnail_create_url = '{0}/info/thumbnail'.format(

--- a/exchange/thumbnails/tasks.py
+++ b/exchange/thumbnails/tasks.py
@@ -578,8 +578,8 @@ def generate_thumbnail_task(instance_id, class_name):
                                'image/png', thumb_png, True)
         else:
             logger.debug(
-                'Thumbnail: Unable to get thumbnail image from '
-                'GeoServer for \'%s\'.',
+                'Thumbnail: Unable to get thumbnail image '
+                'for \'%s\'.',
                 instance_id)
 
 

--- a/exchange/thumbnails/tasks.py
+++ b/exchange/thumbnails/tasks.py
@@ -297,9 +297,12 @@ def get_bbox(instance):
 
 
 def get_wms_thumbnail(instance=None, layers=None, bbox=None,
-                      crs=None, format='image/png', height=None):
+                      format='image/png', height=None):
     if instance is None:
         if bbox is None or height is None:
+            logger.debug('Thumbnail: Could not get wms thumbnail - '
+                         'no instance to fetch bbox & height from, and '
+                         'bbox and height were not given')
             return None
         remote = True
         layers = THUMBNAIL_BACKGROUND_WMS_LAYER
@@ -317,10 +320,15 @@ def get_wms_thumbnail(instance=None, layers=None, bbox=None,
     if layers is None:
         layers = instance.typename.encode('utf-8')
 
-    if bbox is None and instance is not None:
-        bbox, height = get_bbox(instance)
-    elif instance is not None:
-        bbox, height = get_bbox(instance, crs=crs)
+    if bbox is None or height is None:
+        # Should always be true at this point
+        if instance is not None:
+            bbox, height = get_bbox(instance)
+        else:
+            logger.debug('Thumbnail: Could not get wms thumbnail - '
+                         'no instance to fetch bbox & height from, and '
+                         'bbox and height were not given')
+            return None
 
     # base parameters for WMS requests
     params = {

--- a/exchange/thumbnails/tasks.py
+++ b/exchange/thumbnails/tasks.py
@@ -106,8 +106,9 @@ def make_thumb_request(remote, baseurl, params=None):
         else:
             p = ''
 
+        if baseurl.endswith('?') is False:
+            baseurl = baseurl + '?'
         thumbnail_create_url = baseurl + p
-        p = urlparse(thumbnail_create_url)
 
         logger.info(
             'Thumbnail: Requesting thumbnail for %s. ',
@@ -147,6 +148,7 @@ def make_thumb_request(remote, baseurl, params=None):
         logger.debug('content: %s', resp.content)
     except Exception as e:
         logger.exception('Error occured making thumbnail')
+        logger.exception(e)
     return None
 
 

--- a/exchange/thumbnails/views.py
+++ b/exchange/thumbnails/views.py
@@ -25,7 +25,7 @@ def document_thumbnail(objectId):
     try:
         doc = Document.objects.get(id=objectId)
     except Document.DoesNotExist:
-        pass
+        return None
     if doc:
         img = doc._render_thumbnail()
         # save so not needed to generate next time

--- a/exchange/thumbnails/views.py
+++ b/exchange/thumbnails/views.py
@@ -87,10 +87,11 @@ def thumbnail_view(request, objectType, objectId):
                 document_thumbnail(objectId)
             # This case should not occur but represents a failure to save
             except Exception as e:
-                # TODO: Should we return a fail response here?
-                logger.debug('Thumbnail: Failed to save thumbnail for Document'
-                             ' with id: {0}'.format(objectId))
+                content = 'Thumbnail: Failed to save thumbnail for Document ' \
+                          'with id: {0}'.format(objectId)
+                logger.debug(content)
                 logger.debug('Thumbnail: {0}'.format(e))
+                return HttpResponse(status=400, content=content)
             return HttpResponse(status=201)
 
         body_len = len(request.body)


### PR DESCRIPTION
## JIRA Ticket
[GVSD-9821]

## Description
Improvements to thumbnails api. Thumbnails should generate correctly more often and give better error logging and feedback when things go wrong.

Note: MoW currently is causing some jquery conflict on the layer details page which prevents it from spawning modals correctly. Thumbnail feedback can't be viewed with the MoW client at this time.

Additionally, thumbnail setting from the map client on the details page was built to work with the React client. Currently it does not function with MoW. In the future this should be fixed to function with MoW as well.

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
In order to test properly, we will need to use the React viewer instead of MoW for now. On your local instance, disable MoW and enable React by going to `settings/default.py` and setting `GEONODE_CLIENT_ENABLED = True` and `MOW_CLIENT_ENABLED = False`.

Upload local layers and register remote service layers. On their details page, try setting a thumbnail using the mapping client and from file. Thumbnails should be set correctly and should spawn a feedback modal indicating if thumbnails were set correctly or if there was a failure.

If MoW is enabled, you should still be able to set a thumbnail from file, although the feedback modal will not spawn.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa