### PR TITLE
Remove Images tab from download modal and update UI

### DIFF
--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -276,40 +276,13 @@
             <h4 class="modal-title" id="myModalLabel">{% trans "Download Layer" %}</h4>
           </div>
           <div class="modal-body">
-            <div class="tabbable">
-                <ul class="nav nav-tabs">
-                    {% if links %}
-                    <li class="active"><a href="#download_tab1" data-toggle="tab">Images</a></li>
-                    {% endif %}
-                    {% if links_download %}
-                    <li><a href="#download_tab2" data-toggle="tab">Data</a></li>
-                    {% endif %}
-                </ul>
-                <div class="tab-content">
-                {% if links %}
-                    <div class="tab-pane active" id="download_tab1">
-                        <li class="active">
-                            <ul>
-                              {% for link in links %}
-                              <li><a href="{{ link.url }}" target="_blank">{% trans link.name %}</a></li>
-                              {% endfor %}
-                            </ul>
-                        </li>
-                    </div>
-                {% endif %}
-                {% if links_download %}
-                    <div class="tab-pane" id="download_tab2">
-                        <li>
-                            <ul>
-                              {% for link in links_download %}
-                              <li><a href="{{ link.url }}" target="_blank">{% trans link.name %}</a></li>
-                              {% endfor %}
-                            </ul>
-                        </li>
-                    </div>
-                {% endif %}
-                </div>
-            </div>
+            {% if links_download %}
+            <ul>
+              {% for link in links_download %}
+              <li><a href="{{ link.url }}" target="_blank">{% trans link.name %}</a></li>
+              {% endfor %}
+            </ul>
+            {% endif %}
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Close" %}</button>


### PR DESCRIPTION
## JIRA Ticket
[GVSD-8775]

## Description
Removing Image tab as we no longer want to expose this.

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
Upload a layer and navigate to its details page. Click "Download Layer". Only data options should be available, and no tabs as Images were removed.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa