### PR TITLE
Add missing migration

### DIFF
--- a/exchange/3pm/user_messages/0005_auto_20190612_1600.py
+++ b/exchange/3pm/user_messages/0005_auto_20190612_1600.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('auth', '0006_require_contenttypes_0002'),
+        ('user_messages', '0004_auto_20190515_0419'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='GroupMemberThread',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False,
+                                        auto_created=True, primary_key=True)),
+                ('unread', models.BooleanField(default=True)),
+                ('deleted', models.BooleanField(default=False)),
+                ('group', models.ForeignKey(to='auth.Group')),
+            ],
+        ),
+        migrations.RemoveField(
+            model_name='thread',
+            name='users',
+        ),
+        migrations.AddField(
+            model_name='thread',
+            name='single_users',
+            field=models.ManyToManyField(related_name='single_threads',
+                                         verbose_name='Users',
+                                         to=settings.AUTH_USER_MODEL,
+                                         through='user_messages.UserThread',
+                                         blank=True),
+        ),
+        migrations.AlterField(
+            model_name='userthread',
+            name='deleted',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AlterField(
+            model_name='userthread',
+            name='unread',
+            field=models.BooleanField(default=True),
+        ),
+        migrations.AddField(
+            model_name='groupmemberthread',
+            name='thread',
+            field=models.ForeignKey(to='user_messages.Thread'),
+        ),
+        migrations.AddField(
+            model_name='groupmemberthread',
+            name='user',
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name='thread',
+            name='group_users',
+            field=models.ManyToManyField(
+                related_name='group_threads', verbose_name='Group Members',
+                to=settings.AUTH_USER_MODEL,
+                through='user_messages.GroupMemberThread', blank=True),
+        ),
+    ]


### PR DESCRIPTION
## JIRA Ticket
N/A

## Description
This essentially undoes the previous migration `0004_auto_20190515_0419.py`. Unsure why the `0004_auto_20190515_0419.py` was generated to begin with. Previously, Exchange was automatically generating `0004_auto_20190515_0419.py` for some reason, but now it wants it undone. If there is any reason this should not be here, please inform me.

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
Ensure this migration can be run via `python manage.py migrate`. Ensure there are no conflicts or migration errors and Exchange comes up correctly.

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa