### PR TITLE
Bring back Elevation attribute data since metadata permits this

### DIFF
--- a/exchange/static/osgeo_importer/partials/upload.html
+++ b/exchange/static/osgeo_importer/partials/upload.html
@@ -96,7 +96,7 @@
                                             </div>
                                             <div class="col-xs-offset-2 col-sm-offset-2 col-md-offset-2 col-md-8 col-lg-8" style="padding: 10px; display: table-cell; text-align: center">
                                                 <span style="color:#FF4136;" ng-show="hasFailure()">This import has failed.  Adjust configuration above.</span>
-                                                <span style="color:#3D9970;" ng-show="successful()">The import has finished successfully. View the <a href="{{layer.geonode_layer.url}}" style="font-weight: 600">Layer</a>.</span>
+                                                <span style="color:#3D9970;" ng-show="successful()">The import has finished successfully. Complete the <a href="{{layer.geonode_layer.url}}/metadata" style="font-weight: 600">Layer's Metadata</a>.</span>
                                             </div>
                                             <div class="btn btn-sm col-xs-offset-4 col-sm-offset-4 col-md-offset-4 col-md-3 btn-success import-button" ng-click="open(layer, staticUrl + '/osgeo_importer/partials/uploadWizard.html', staticUrl + 'geonode/img/logo.png', staticUrl)" ng-controller="ImportController" ng-class="{'disabled': !isValid()}">&gt;&gt;Import
                                                 <i class="fa" ng-class="{'fa-circle-o-notch fa-spin': processing(), 'fa-arrow-circle-right': !processing()}"></i>

--- a/exchange/static/osgeo_importer/partials/uploadWizard.html
+++ b/exchange/static/osgeo_importer/partials/uploadWizard.html
@@ -207,7 +207,7 @@
                     <p>Click the button below to begin the import.</p></div>
                 <div class="step-title" ng-show="success">
                     <h3><center>Import Complete</center></h3>
-                    <p><b>Congratulations!</b> The {{ layer.configuration_options.name }} dataset has been successfully imported. Click below to view your new Layer.</p>
+                    <p><b>Congratulations!</b> The {{ layer.configuration_options.name }} dataset has been successfully imported. Click below to complete the Layer's metadata.</p>
                 </div>
                 <div ng-show="errors">
                     <h3 align="center">Import Failed</h3>
@@ -215,8 +215,8 @@
                 </div>
                 <div class="row" ng-show="success">
                     <div align="center">
-                        <a href="{{ layer.geonode_layer.url }}" class="btn" target="_self">
-                           View Layer
+                        <a href="{{ layer.geonode_layer.url }}/metadata" class="btn" target="_self">
+                           Complete Layer Metadata
                         </a>
                     </div>
                 </div>

--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -210,11 +210,11 @@
                     <td>{% if resource.has_time %}{% trans "True" %}{% else %}{% trans "False" %}{% endif %}</td>
                     <td>{% if resource.time_regex %}{{ resource.time_regex }}{% else %}&nbsp;{% endif %}</td>
                   </tr>
-                  <!-- tr>
+                  <tr>
                     <td title="ELEVATION">{% trans "ELEVATION" %}</td>
                     <td>{% if resource.has_elevation %}{% trans "True" %}{% else %}{% trans "False" %}{% endif %}</td>
                     <td>{% if resource.elevation_regex %}{{ resource.elevation_regex }}{% else %}&nbsp;{% endif %}</td>
-                  </tr -->
+                  </tr>
               </tbody>
             </table>
         {% endif %}


### PR DESCRIPTION
## JIRA Ticket
[GVSD-9820]

## Description
NOTE: Coincides with GeoNode PR https://github.com/boundlessgeo/geonode/pull/282

Updates to Exchange's metadata to correct and streamline based on current offering.

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
Upload a layer via the osgeo-importer. You should now be redirected to its metadata immediately. Additionally, the edit metadata should be updated, removing information that is outdated or should not be modifiable by the user, and making the existing information easier to understand.

NOTE: Does elevation data work properly within Exchange? Should be able to read from image mosaics if used within Exchange

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa