### PR TITLE
Gvsd 8798

### DIFF
--- a/exchange/templates/layers/MOW_map.html
+++ b/exchange/templates/layers/MOW_map.html
@@ -4,7 +4,10 @@
     document.addEventListener("DOMContentLoaded", function (event) {
         const viewer = {{ viewer|safe }};
         let isSelected = false;
-        let isVisible = viewer.visibility || true;
+        let isVisible = true;
+        if (viewer.visibility != null && viewer.visibility != undefined) {
+            isVisible = viewer.visibility;
+        }
 
         $('#layerselect').click(function() {
             if(isSelected) {

--- a/exchange/templates/layers/MOW_map.html
+++ b/exchange/templates/layers/MOW_map.html
@@ -2,7 +2,10 @@
 
 <script type="text/javascript">
     document.addEventListener("DOMContentLoaded", function (event) {
-        var isSelected = false;
+        const viewer = {{ viewer|safe }};
+        let isSelected = false;
+        let isVisible = viewer.visibility || true;
+
         $('#layerselect').click(function() {
             if(isSelected) {
                 $("#layerlist").removeClass("mow-layer-list-show");
@@ -12,8 +15,27 @@
             isSelected = !isSelected;
         });
         
-        var viewer = {{ viewer|safe }}
-
+        $('#mow-change-visibility').click(function() {
+            // Get list of layers
+            const layers = map.getOverlays();  
+            //Change visibility variable
+            isVisible = !isVisible;  
+            // Find the trgetLayer in list of layers
+            const targetLayer = layers.find(function(layer) {
+                return layer.name === viewer.typename;
+            });
+            // Change the Eye Icon
+            if(isVisible){
+                $("#mow-vis-eye").removeClass("fa-eye-slash");
+                $("#mow-vis-eye").addClass("fa-eye");
+            } else {
+                $("#mow-vis-eye").removeClass("fa-eye");
+                $("#mow-vis-eye").addClass("fa-eye-slash");
+            }
+            // Change Visibility
+            map.setVisibility(targetLayer.id, isVisible);
+        });
+        
         MoW.ready(function() {
                 map = new MoW.Map({target: 'preview_map'});
                 var wmsOverlay;
@@ -21,25 +43,23 @@
                     wmsOverlay = MoW.Factory.createArcGISOverlay({
                         'url': viewer.url,
                         'description': viewer.typename,
-                        'name': viewer.typename
+                        'name': viewer.typename,
                     });
                     map.setExtent(viewer.bbox);
-                    map.addOverlay(wmsOverlay);
+                    map.addOverlay(wmsOverlay, {isVisible: isVisible});
                 } else if (viewer.ptype === 'gxp_wmscsource'){
                     wmsOverlay = MoW.Factory.createWMSOverlay({
                         'url': viewer.url,
                         'layers': [viewer.typename],
-                        'name': viewer.typename
+                        'name': viewer.typename,
                     });
-                    map.addOverlay(wmsOverlay);
+                    map.addOverlay(wmsOverlay, {isVisible: isVisible});
                     map.setExtent(viewer.bbox);
                 } else {
                     var alert = new MoW.Alert(MoW.Alert.TYPE.ERROR, "Not valid layer", "Cannot connect to service");
                     map.showAlert(alert);
                 }
-
                 $('#autoscaleBase').click(function() {
-                    console.log(MoW.Basemap.ID);
                     map.setBasemap(MoW.Basemap.ID.AUTOSCALING);
                     isSelected = false;
                     $("#layerlist").removeClass("mow-layer-list-show");

--- a/exchange/templates/layers/layer_detail.html
+++ b/exchange/templates/layers/layer_detail.html
@@ -50,13 +50,20 @@
       <div id="preview_map" class="details_map">
         {% if preview == 'MOW' %}
         <div class='layerlist'>
-            <div class="layerbutton"><div id="layerselect" class="layerinfo"><i class="fa fa-ellipsis-h ellipsis"></i></div>
+            <div class="layerbutton"><div id="layerselect" class="layerinfo"><i class="fa fa-ellipsis-h fa-ell-button-on-map"></i></div>
               <ul class="mow-layer-list" id="layerlist">
                 <li class='layeroption' id="autoscaleBase"><a class="layerinfo" href="#">Autoscale</a></li>
                 <li class='layeroption' id="canvasgrayBase"><a class="layerinfo" href="#">Grey</a></li>
                 <li class='layeroption' id="streetsBase"><a class="layerinfo" href="#">Streets</a></li>
               </ul>
             </div>
+        </div>
+        <div class='mow-visibility' id='mow-change-visibility'>
+          <div class="layerbutton" >
+            <div class="layerinfo">
+              <i id='mow-vis-eye' class="fa fa-eye fa-eye-button-on-map"></i>
+            </div>
+          </div>
         </div>
         {% endif %}
       </div>   

--- a/exchange/themes/static/theme/css/site_base.css
+++ b/exchange/themes/static/theme/css/site_base.css
@@ -450,6 +450,8 @@ h1, h2, h3, h4, h5, h6 {
   }
   .fa-eye-button-on-map {
       line-height: .8;
+      position: relative;
+      right: 2px;
   }
 
   .layerinfo{

--- a/exchange/themes/static/theme/css/site_base.css
+++ b/exchange/themes/static/theme/css/site_base.css
@@ -397,7 +397,13 @@ h1, h2, h3, h4, h5, h6 {
       z-index: 1000;
       font-size: 20px;
   }
-  
+  .mow-visibility {
+    padding: 5px;
+    position: absolute;
+    right: 60px;
+    z-index: 1000;
+    font-size: 20px;
+  }
   .mow-layer-list .layerlist {
     background: darkorange;
     list-style: none;
@@ -439,8 +445,11 @@ h1, h2, h3, h4, h5, h6 {
     border-radius: 25px;
   }
 
-  .ellipsis {
+  .fa-ell-button-on-map {
       line-height: .9;
+  }
+  .fa-eye-button-on-map {
+      line-height: .8;
   }
 
   .layerinfo{

--- a/exchange/views.py
+++ b/exchange/views.py
@@ -460,7 +460,7 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
             'ptype': layer.ptype,
             'url': layer.ows_url,
             'typename': layer.typename,
-            "visibility": layer.visibility
+            'visibility': layer.visibility
         })
     else:
         context_dict["viewer"] = json.dumps(

--- a/exchange/views.py
+++ b/exchange/views.py
@@ -336,7 +336,8 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
             "remote": True,
             "url": source_url,
             "name": service.name,
-            "use_proxy": use_proxy}
+            "use_proxy": use_proxy,
+            "visibility": layer.visibility}
         if query_params is not None:
             source_params["params"] = query_params
         if layer.alternate is not None:
@@ -458,7 +459,8 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
             'bbox': config['bbox'],
             'ptype': layer.ptype,
             'url': layer.ows_url,
-            'typename': layer.typename
+            'typename': layer.typename,
+            "visibility": layer.visibility
         })
     else:
         context_dict["viewer"] = json.dumps(


### PR DESCRIPTION
## JIRA Ticket
[GVSD-8798]

## Description
Adds a visibility toggle to Map of the World viewer.
Detects visibility of layers, including remote service settings, and applies it to the layer model. Map of the World viewer receives the value and uses it as default visibility.

Note: Coincides with GeoNode PR https://github.com/boundlessgeo/geonode/pull/284

## TODO
- [ ] pycodestyle (`make lint`)
- [ ] tests (`make test`)

## Steps to Test or Reproduce
1. Start on `gvs-pki` branch and upload at least one layer.
2. Check out both `GVSD-8798` branches and restart Exchange - this should apply necessary migrations.
3. Ensure the previously uploaded layer is still viewable (no errors on details page)
4. Upload remote services with default visibility set and ensure the view details page for imported layers reflect the visibility. Example services:
https://gis.fema.gov/arcgis/rest/services/NSS/NSS_flex_facilities/MapServer
https://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_APPS/MySchoolsDC/MapServer
http://services.arcgisonline.com/arcgis/rest/services/Polar/Antarctic_Imagery/MapServer

## Setup Environment with PR

1. Cleanup previous state

```bash
make purge
```

2. Checkout PR

__Using git command (command line interface)__
```bash
pr_id=ADD_PR_NUMBER_HERE
git checkout master
git branch -D $pr_id
git fetch
git fetch origin pull/$pr_id/head:$pr_id
git checkout $pr_id
git submodule init
git submodule update --remote --recursive
```

__Using [Gitkraken](https://www.gitkraken.com/)__

+ In GitKraken, right click on the pull request you want to review. Select Add Remote and Checkout (the PR).

3. Start exchange

```bash
make start
```

4. Exchange Healthcheck

```bash
docker inspect --format '{{ .State.Health.Status }}' exchange
```

__NOTE:__ Only continue the following steps if the output from the above command is `healthy`. You may have to wait 
a few minutes.

---
@boundlessgeo/bex-qa